### PR TITLE
fix(ci): pin ruff and select lint rules explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,21 +11,25 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install ruff
-        run: python -m pip install ruff
+        # Pinned via requirements-dev.txt - an unpinned ruff picks up new
+        # default rules on every release and breaks CI without a code change.
+        run: python -m pip install "$(grep '^ruff==' requirements-dev.txt)"
       - name: Run ruff
         run: ruff check .
+      - name: Check formatting
+        run: ruff format --check .
 
   hassfest:
     name: Hassfest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Hassfest validation
         uses: home-assistant/actions/hassfest@master
 
@@ -33,7 +37,7 @@ jobs:
     name: HACS Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: HACS Action
         uses: hacs/action@main
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.16.3
     hooks:
       - id: ruff
         args: [--fix]

--- a/custom_components/chmu/__init__.py
+++ b/custom_components/chmu/__init__.py
@@ -11,8 +11,8 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .const import DOMAIN
 from .api import ChmuApi
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/chmu/api.py
+++ b/custom_components/chmu/api.py
@@ -3,7 +3,7 @@
 import logging
 import re
 from datetime import datetime, timedelta
-from typing import Any, Dict, Optional
+from typing import Any
 
 import requests
 
@@ -17,7 +17,7 @@ _CR_TEXT_FORECAST_RE = re.compile(
 
 def _fetch_metadata_with_fallback(
     session: requests.Session, log_context: str
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Fetch today's metadata or fall back to previous day when necessary."""
     date_str = datetime.now().strftime("%Y%m%d")
     filename = f"meta1-{date_str}.json"
@@ -46,7 +46,7 @@ def _fetch_metadata_with_fallback(
         raise
 
 
-def get_stations() -> Dict[str, str]:
+def get_stations() -> dict[str, str]:
     """Fetch available stations from ČHMÚ metadata."""
     session = requests.Session()
     session.headers.update({"User-Agent": "Home-Assistant-CHMU-Integration/1.0"})
@@ -87,7 +87,7 @@ def get_stations() -> Dict[str, str]:
         }
 
 
-def get_stations_with_coords() -> Dict[str, Dict[str, Any]]:
+def get_stations_with_coords() -> dict[str, dict[str, Any]]:
     """Fetch available stations with coordinates from ČHMÚ metadata.
 
     Returns:
@@ -159,7 +159,7 @@ def get_stations_with_coords() -> Dict[str, Dict[str, Any]]:
 class ChmuApi:
     """API client for ČHMÚ weather data."""
 
-    def __init__(self, station_id: str, station_name: Optional[str] = None):
+    def __init__(self, station_id: str, station_name: str | None = None):
         """Initialize the API client."""
         self.station_id = station_id
         self.station_name = station_name or f"Station {station_id}"
@@ -168,7 +168,7 @@ class ChmuApi:
             {"User-Agent": "Home-Assistant-CHMU-Integration/1.0"}
         )
 
-    def get_current_data(self) -> Dict[str, Any]:
+    def get_current_data(self) -> dict[str, Any]:
         """Get current weather data from ČHMÚ."""
         now = datetime.now()
 
@@ -195,7 +195,7 @@ class ChmuApi:
 
         return data
 
-    def _fetch_10min_data(self, date: datetime) -> Optional[Dict[str, Any]]:
+    def _fetch_10min_data(self, date: datetime) -> dict[str, Any] | None:
         """Fetch 10-minute interval data for a specific date."""
         # Format: 10m-0-20000-0-{station_id}-{YYYYMMDD}.json
         date_str = date.strftime("%Y%m%d")
@@ -216,7 +216,7 @@ class ChmuApi:
                 return None
             raise
 
-    def _parse_chmu_data(self, json_data: Dict[str, Any]) -> Dict[str, Any]:
+    def _parse_chmu_data(self, json_data: dict[str, Any]) -> dict[str, Any]:
         """Parse CHMU JSON data format.
 
         Data format:
@@ -275,7 +275,7 @@ class ChmuApi:
         _LOGGER.debug(f"Parsed data: {result}")
         return result
 
-    def _fetch_latest_cr_text_forecast(self) -> Dict[str, Any]:
+    def _fetch_latest_cr_text_forecast(self) -> dict[str, Any]:
         """Fetch latest Czech Republic text forecast JSON."""
         index_url = f"{API_FORECAST_NOW_URL}/"
         index_response = self.session.get(index_url, timeout=30)
@@ -292,7 +292,7 @@ class ChmuApi:
         forecast_response.raise_for_status()
         return forecast_response.json()
 
-    def _parse_latest_cr_text_filename(self, index_html: str) -> Optional[str]:
+    def _parse_latest_cr_text_filename(self, index_html: str) -> str | None:
         """Parse index HTML and return the latest web_pCRntx file."""
         candidates: list[tuple[datetime, str]] = []
 
@@ -308,9 +308,7 @@ class ChmuApi:
 
         return max(candidates, key=lambda item: item[0])[1]
 
-    def _extract_weather_description(
-        self, forecast_json: Dict[str, Any]
-    ) -> Optional[str]:
+    def _extract_weather_description(self, forecast_json: dict[str, Any]) -> str | None:
         """Extract weather description from forecast JSON."""
         features = forecast_json.get("data", {}).get("features", [])
         if not isinstance(features, list):

--- a/custom_components/chmu/config_flow.py
+++ b/custom_components/chmu/config_flow.py
@@ -1,10 +1,9 @@
 """Config flow for ČHMÚ Weather integration."""
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any
 
 import voluptuous as vol
-
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
@@ -20,7 +19,7 @@ def calculate_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> fl
 
     Returns distance in kilometers.
     """
-    from math import radians, sin, cos, sqrt, atan2
+    from math import atan2, cos, radians, sin, sqrt
 
     # Earth radius in kilometers
     R = 6371.0
@@ -41,8 +40,8 @@ def calculate_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> fl
 
 
 def find_nearest_station(
-    home_lat: float, home_lon: float, stations: Dict[str, Dict[str, Any]]
-) -> Optional[str]:
+    home_lat: float, home_lon: float, stations: dict[str, dict[str, Any]]
+) -> str | None:
     """Find the nearest station to home coordinates.
 
     Returns station ID of the nearest station.
@@ -72,7 +71,7 @@ class ChmuConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
     async def async_step_user(
-        self, user_input: Optional[Dict[str, Any]] = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step."""
         errors = {}

--- a/custom_components/chmu/sensor.py
+++ b/custom_components/chmu/sensor.py
@@ -10,10 +10,10 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
+    UnitOfPrecipitationDepth,
     UnitOfPressure,
     UnitOfSpeed,
     UnitOfTemperature,
-    UnitOfPrecipitationDepth,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
 # Development dependencies
-ruff>=0.6.0
+# ruff is pinned exactly: its default rule set changes between minor releases
+# (0.16.0 broke CI), so CI, pre-commit and local runs must use the same version.
+ruff==0.16.3
 pre-commit>=3.5.0
 pytest>=8.3.0
 requests>=2.31.0

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,23 @@
+# Ruff configuration.
+#
+# The rule set is selected explicitly on purpose: ruff changed its *default*
+# selection in 0.16.0, which silently broke CI on repos that relied on the
+# implicit defaults. Pin both the ruff version (requirements-dev.txt,
+# .pre-commit-config.yaml, .github/workflows/ci.yml) and the rules here.
+
+target-version = "py311"
+line-length = 88
+
+exclude = [".venv", "assets"]
+
+[lint]
+select = [
+    "E4",   # pycodestyle - imports
+    "E7",   # pycodestyle - statements
+    "E9",   # pycodestyle - runtime errors
+    "F",    # pyflakes
+    "I",    # isort
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "SIM",  # flake8-simplify
+]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,11 +1,11 @@
 """Tests for CHMU API helpers."""
 
+import sys
 from datetime import datetime
 from importlib import import_module
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
-import sys
 
 import pytest
 import requests


### PR DESCRIPTION
## Problem

CI has failed on every scheduled run since **2026-07-24** (last green: 2026-07-23), with no code change in between — the last commit is from 2026-03-05.

The `Lint` job installs ruff unpinned (`pip install ruff`). Ruff **0.16.0** was published **2026-07-23 19:10 UTC**, hours before the first failing nightly run, and it widened the *default* rule selection well beyond the previous `E4,E7,E9,F`. `ruff check .` then reported 33 errors (`I001`, `UP006/UP035/UP045`, `DTZ005/DTZ007`, `TRY401`) on unchanged code.

## Fix

- **`ruff.toml`** — explicit rule selection (`E4`, `E7`, `E9`, `F`, `I`, `UP`, `B`, `SIM`), so lint results no longer track ruff's shifting defaults.
- **Pin `ruff==0.16.3`** in `requirements-dev.txt`, install that pin in CI, bump the ruff pre-commit rev to `v0.16.3` — CI, pre-commit and `lint.sh` now run the same version.
- **Apply the resulting fixes**: import sorting, `typing.Dict` → `dict`, `Optional[X]` → `X | None`. Mechanical only.
- **`ruff format --check`** added to CI, matching `lint.sh`.
- **`actions/checkout@v5`, `actions/setup-python@v6`** — clears the Node 20 EOL warnings.

`DTZ005`/`DTZ007`/`TRY401` are intentionally out of the selected set: `datetime.now()` here is naive-local on purpose (ČHMÚ publishes files keyed by local Czech date), and changing that is a behaviour change, not a CI fix.

## Verification

- `./lint.sh` — green (ruff check + format + HACS validation)
- `pytest tests/` — 4 passed
- CI on this branch: Lint / Hassfest / HACS Validation all ✓ ([run 31967614963](https://github.com/lipelix/home-assistant-chmu-weather/actions/runs/31967614963))
