### PR TITLE
feat(forecast): publish per-station ALADIN forecast data

### DIFF
--- a/.github/workflows/forecast-data.yml
+++ b/.github/workflows/forecast-data.yml
@@ -1,0 +1,56 @@
+name: Forecast data
+
+# Samples the ČHMÚ ALADIN CZ_1km model at every station coordinate and publishes
+# the result as a static site, so the integration downloads a few kilobytes for
+# its own station instead of ~70 MB of GRIB for the whole country.
+#
+# ALADIN runs at 00/06/12/18 UTC and lands on opendata roughly 75 minutes later;
+# these times leave a margin on top of that.
+
+on:
+  schedule:
+    - cron: "30 1,7,13,19 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# A late run must not overwrite a newer one, and a stuck run must not block the
+# next model cycle.
+concurrency:
+  group: forecast-data
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      # No third-party dependencies on purpose: tools/aladin.py decodes GRIB1
+      # with the standard library only.
+      - name: Build forecast data
+        run: python tools/build_forecast_data.py --out dist
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: dist
+
+      - name: Deploy to Pages
+        id: deploy
+        uses: actions/deploy-pages@v5

--- a/tests/test_aladin.py
+++ b/tests/test_aladin.py
@@ -1,0 +1,159 @@
+"""Tests for the ALADIN GRIB1 reader.
+
+The messages are built by hand so the bit level maths is checked without
+downloading tens of megabytes from ČHMÚ in CI.
+"""
+
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "tools") not in sys.path:
+    sys.path.insert(0, str(ROOT / "tools"))
+
+from aladin import Grid, iter_messages  # noqa: E402
+
+# 3 x 2 grid starting at 50.0 N, 14.0 E with 0.5 degree spacing.
+NI, NJ = 3, 2
+
+
+def _u3(value: int) -> bytes:
+    return value.to_bytes(3, "big")
+
+
+def _i3(value: int) -> bytes:
+    return (abs(value) | (0x800000 if value < 0 else 0)).to_bytes(3, "big")
+
+
+def _i2(value: int) -> bytes:
+    return (abs(value) | (0x8000 if value < 0 else 0)).to_bytes(2, "big")
+
+
+def _pds(*, param=11, p1=0, p2=6, tri=10, decimal_scale=0) -> bytes:
+    body = bytes(
+        [
+            0,  # table version
+            88,  # centre
+            1,  # generating process
+            255,  # grid id, defined in the GDS
+            0x80,  # GDS present, no bitmap
+            param,
+            105,  # level type
+        ]
+    )
+    body += (2).to_bytes(2, "big")  # level
+    body += bytes([26, 9, 8, 0, 0])  # 2026-09-08 00:00 reference time
+    body += bytes([1, p1, p2, tri])  # hour unit, P1, P2, time range indicator
+    body += (0).to_bytes(2, "big")  # number averaged
+    body += bytes([0, 21, 0])  # missing, century, subcentre
+    body += _i2(decimal_scale)
+    return _u3(len(body) + 3) + body
+
+
+def _gds() -> bytes:
+    body = bytes([255, 255, 0])  # NV, PV, data representation type (latlon)
+    body += NI.to_bytes(2, "big") + NJ.to_bytes(2, "big")
+    body += _i3(50_000) + _i3(14_000)  # La1, Lo1 in millidegrees
+    body += bytes([0x88])  # resolution and component flags
+    body += _i3(50_500) + _i3(15_000)  # La2, Lo2
+    body += _i2(500) + _i2(500)  # Di, Dj
+    body += bytes([0x40])  # scanning mode: west to east, south to north
+    body += bytes(4)  # reserved
+    return _u3(len(body) + 3) + body
+
+
+def _bds(values: list[int], *, bits=8, binary_scale=0, reference=0.0) -> bytes:
+    packed = 0
+    for value in values:
+        packed = (packed << bits) | value
+    width = (len(values) * bits + 7) // 8
+    body = bytes([0x00])  # grid point, simple packing, float, no extra flags
+    body += _i2(binary_scale)
+    # IBM float encoding of the reference value; only 0.0 is needed here.
+    assert reference == 0.0, "test helper only encodes a zero reference value"
+    body += bytes(4)
+    body += bytes([bits])
+    body += packed.to_bytes(width, "big")
+    return _u3(len(body) + 3) + body
+
+
+def _message(values: list[int], **pds_kwargs) -> bytes:
+    sections = _pds(**pds_kwargs) + _gds() + _bds(values)
+    total = 8 + len(sections) + 4
+    return b"GRIB" + _u3(total) + bytes([1]) + sections + b"7777"
+
+
+def test_grid_index_is_row_major_from_the_south_west_corner():
+    grid = Grid(ni=NI, nj=NJ, lat1=50.0, lon1=14.0, di=0.5, dj=0.5)
+
+    assert grid.index(50.0, 14.0) == 0
+    assert grid.index(50.0, 15.0) == 2
+    assert grid.index(50.5, 14.0) == NI
+    assert grid.index(50.5, 15.0) == NI + 2
+
+
+def test_grid_index_snaps_to_the_nearest_point():
+    grid = Grid(ni=NI, nj=NJ, lat1=50.0, lon1=14.0, di=0.5, dj=0.5)
+
+    assert grid.index(50.04, 14.49) == 1
+
+
+def test_grid_rejects_points_outside_the_domain():
+    grid = Grid(ni=NI, nj=NJ, lat1=50.0, lon1=14.0, di=0.5, dj=0.5)
+
+    assert not grid.contains(48.0, 14.0)
+    with pytest.raises(ValueError, match="outside"):
+        grid.index(48.0, 14.0)
+
+
+def test_reads_packed_values_at_a_point():
+    message = next(iter_messages(_message([10, 20, 30, 40, 50, 60])))
+
+    assert message.parameter == 11
+    assert message.value_at(0) == pytest.approx(10.0)
+    assert message.value_at(5) == pytest.approx(60.0)
+    assert message.value_at(message.grid.index(50.5, 14.5)) == pytest.approx(50.0)
+
+
+def test_applies_binary_and_decimal_scaling():
+    sections = _pds(decimal_scale=1) + _gds() + _bds([4] * 6, binary_scale=2)
+    raw = b"GRIB" + _u3(8 + len(sections) + 4) + bytes([1]) + sections + b"7777"
+
+    message = next(iter_messages(raw))
+
+    # (0 + 4 * 2**2) / 10**1
+    assert message.value_at(0) == pytest.approx(1.6)
+
+
+def test_time_range_indicator_10_uses_two_octets_for_the_step():
+    message = next(iter_messages(_message([0] * 6, p1=1, p2=8, tri=10)))
+
+    # (1 << 8) | 8 == 264 hours after the 2026-09-08 00Z reference time
+    assert message.valid_time == datetime(2026, 9, 19, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    ("tri", "p1", "p2", "expected_hour"),
+    [(0, 5, 0, 5), (1, 0, 0, 0), (4, 0, 9, 9)],
+)
+def test_supported_time_range_indicators(tri, p1, p2, expected_hour):
+    message = next(iter_messages(_message([0] * 6, p1=p1, p2=p2, tri=tri)))
+
+    assert message.valid_time == datetime(2026, 9, 8, expected_hour, tzinfo=UTC)
+
+
+def test_rejects_an_unknown_time_range_indicator():
+    with pytest.raises(ValueError, match="time range indicator"):
+        next(iter_messages(_message([0] * 6, tri=3)))
+
+
+def test_iterates_every_message_in_a_file():
+    raw = _message([1] * 6, p2=6) + _message([2] * 6, p2=12)
+
+    messages = list(iter_messages(raw))
+
+    assert [m.valid_time.hour for m in messages] == [6, 12]
+    assert [m.value_at(0) for m in messages] == [1.0, 2.0]

--- a/tools/aladin.py
+++ b/tools/aladin.py
@@ -1,0 +1,202 @@
+"""Minimal GRIB edition 1 reader for ČHMÚ ALADIN CZ_1km open data.
+
+The ALADIN CZ_1km files are a lucky special case: a regular latitude/longitude
+grid with simple (fixed bit width) packing and no bitmap. That means a single
+grid point can be read with plain bit arithmetic - no eccodes, no cfgrib, no
+numpy, nothing outside the standard library.
+
+Only the subset of GRIB1 that ČHMÚ actually emits is implemented. Anything else
+raises, on purpose: silently mis-decoding weather data is worse than failing.
+
+Reference: https://opendata.chmi.cz/meteorology/weather/nwp_aladin/
+"""
+
+from __future__ import annotations
+
+import bz2
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+# Grid definition section, data representation type (octet 6).
+_GDS_LATLON = 0
+
+# Binary data section flags (octet 4). The high nibble must be all zero:
+# grid point data, simple packing, float values, no additional flags.
+_BDS_SIMPLE_PACKING = 0x00
+
+# Time range indicator values we know how to turn into a valid time.
+_TRI_INSTANT = 0  # valid at reference + P1
+_TRI_ANALYSIS = 1  # the analysis itself, valid at the reference time
+_TRI_ACCUMULATION = 4  # accumulated over reference + P1 .. reference + P2
+_TRI_P1_IS_TWO_OCTETS = 10  # valid at reference + (P1 << 8 | P2)
+
+
+def _u3(b: bytes) -> int:
+    return (b[0] << 16) | (b[1] << 8) | b[2]
+
+
+def _i2(b: bytes) -> int:
+    v = (b[0] << 8) | b[1]
+    return -(v & 0x7FFF) if v & 0x8000 else v
+
+
+def _i3(b: bytes) -> int:
+    v = _u3(b)
+    return -(v & 0x7FFFFF) if v & 0x800000 else v
+
+
+def _ibm_float(b: bytes) -> float:
+    """Decode a 4 byte IBM/360 single precision float (GRIB1 reference value)."""
+    sign = -1 if b[0] & 0x80 else 1
+    exponent = (b[0] & 0x7F) - 64
+    mantissa = (b[1] << 16) | (b[2] << 8) | b[3]
+    return sign * mantissa * (16.0**exponent) / (1 << 24)
+
+
+@dataclass(frozen=True)
+class Grid:
+    """Regular latitude/longitude grid, as described by the GRIB1 GDS."""
+
+    ni: int
+    nj: int
+    lat1: float
+    lon1: float
+    di: float
+    dj: float
+
+    @classmethod
+    def from_gds(cls, gds: bytes) -> Grid:
+        if gds[5] != _GDS_LATLON:
+            raise ValueError(f"unsupported GRIB1 grid type {gds[5]}, expected latlon")
+        return cls(
+            ni=(gds[6] << 8) | gds[7],
+            nj=(gds[8] << 8) | gds[9],
+            lat1=_i3(gds[10:13]) / 1000,
+            lon1=_i3(gds[13:16]) / 1000,
+            di=_i2(gds[23:25]) / 1000,
+            dj=_i2(gds[25:27]) / 1000,
+        )
+
+    def contains(self, lat: float, lon: float) -> bool:
+        i = round((lon - self.lon1) / self.di)
+        j = round((lat - self.lat1) / self.dj)
+        return 0 <= i < self.ni and 0 <= j < self.nj
+
+    def index(self, lat: float, lon: float) -> int:
+        """Return the flat index of the grid point nearest to lat/lon.
+
+        Scanning mode 0x40 (west to east, south to north, i consecutive) is the
+        only one ČHMÚ uses for this product, so the layout is simply j * ni + i.
+        """
+        i = round((lon - self.lon1) / self.di)
+        j = round((lat - self.lat1) / self.dj)
+        if not (0 <= i < self.ni and 0 <= j < self.nj):
+            raise ValueError(f"point {lat},{lon} outside the ALADIN CZ_1km domain")
+        return j * self.ni + i
+
+
+@dataclass
+class Message:
+    """One decoded GRIB1 message: a single parameter at a single valid time."""
+
+    parameter: int
+    valid_time: datetime
+    grid: Grid
+    _reference: float
+    _binary_scale: int
+    _decimal_scale: int
+    _bits: int
+    _data: bytes
+
+    def value_at(self, index: int) -> float:
+        """Read one packed value by flat grid index."""
+        bit = index * self._bits
+        first = bit // 8
+        offset = bit % 8
+        span = (offset + self._bits + 7) // 8
+        chunk = int.from_bytes(self._data[first : first + span], "big")
+        packed = (chunk >> (span * 8 - offset - self._bits)) & ((1 << self._bits) - 1)
+        scaled = self._reference + packed * 2.0**self._binary_scale
+        return scaled / 10.0**self._decimal_scale
+
+
+def _valid_time(pds: bytes) -> datetime:
+    century, year = pds[24], pds[12]
+    reference = datetime(
+        (century - 1) * 100 + year, pds[13], pds[14], pds[15], pds[16], tzinfo=UTC
+    )
+
+    unit, p1, p2, tri = pds[17], pds[18], pds[19], pds[20]
+    if unit != 1:
+        raise ValueError(f"unsupported GRIB1 time unit {unit}, expected hours")
+
+    if tri == _TRI_ANALYSIS:
+        step = 0
+    elif tri == _TRI_INSTANT:
+        step = p1
+    elif tri in (_TRI_ACCUMULATION, _TRI_P1_IS_TWO_OCTETS):
+        # Accumulations are stamped with the end of their period; for TRI 10 the
+        # two octets together are the (larger than 255) forecast step.
+        step = (p1 << 8) | p2 if tri == _TRI_P1_IS_TWO_OCTETS else p2
+    else:
+        raise ValueError(f"unsupported GRIB1 time range indicator {tri}")
+
+    return reference + timedelta(hours=step)
+
+
+def iter_messages(raw: bytes) -> Iterator[Message]:
+    """Walk every GRIB1 message in a decompressed ALADIN file."""
+    offset = 0
+    while offset < len(raw):
+        if raw[offset : offset + 4] != b"GRIB":
+            raise ValueError(f"expected a GRIB header at byte {offset}")
+        total = _u3(raw[offset + 4 : offset + 7])
+        if raw[offset + 7] != 1:
+            raise ValueError(f"unsupported GRIB edition {raw[offset + 7]}, expected 1")
+
+        cursor = offset + 8
+        pds = raw[cursor : cursor + _u3(raw[cursor : cursor + 3])]
+        cursor += len(pds)
+
+        if not pds[7] & 0x80:
+            raise ValueError("message has no grid definition section")
+        gds = raw[cursor : cursor + _u3(raw[cursor : cursor + 3])]
+        cursor += len(gds)
+
+        if pds[7] & 0x40:
+            raise ValueError("bitmapped messages are not supported")
+
+        bds = raw[cursor : cursor + _u3(raw[cursor : cursor + 3])]
+        if bds[3] & 0xF0 != _BDS_SIMPLE_PACKING:
+            raise ValueError(f"unsupported BDS packing flags {bds[3]:#04x}")
+
+        yield Message(
+            parameter=pds[8],
+            valid_time=_valid_time(pds),
+            grid=Grid.from_gds(gds),
+            _reference=_ibm_float(bds[6:10]),
+            _binary_scale=_i2(bds[4:6]),
+            _decimal_scale=_i2(pds[26:28]),
+            _bits=bds[10],
+            _data=bds[11:],
+        )
+        offset += total
+
+
+def series_at_points(
+    compressed: bytes, coordinates: Sequence[tuple[float, float]]
+) -> dict[datetime, list[float]]:
+    """Decode a .grb.bz2 blob into {valid_time: [value per coordinate]}.
+
+    Every message is visited once and sampled for all coordinates, so adding
+    stations costs a few bit reads rather than another pass over the file.
+    """
+    raw = bz2.decompress(compressed)
+    series: dict[datetime, list[float]] = {}
+    indices: list[int] | None = None
+    for message in iter_messages(raw):
+        if indices is None:
+            indices = [message.grid.index(lat, lon) for lat, lon in coordinates]
+        series[message.valid_time] = [message.value_at(i) for i in indices]
+    return series

--- a/tools/build_forecast_data.py
+++ b/tools/build_forecast_data.py
@@ -1,0 +1,247 @@
+"""Build per-station forecast JSON from ČHMÚ ALADIN CZ_1km open data.
+
+Runs in CI, not in Home Assistant. It downloads one ALADIN model run (~63 MB),
+samples every ČHMÚ station coordinate out of the 1 km grid and writes a small
+JSON per station. The integration then fetches a few kilobytes instead of tens
+of megabytes, and gets a forecast for its own station instead of a national one.
+
+Output layout (published as a static site):
+
+    v1/index.json          run metadata + station list
+    v1/<station-wsi>.json  hourly and daily forecast for one station
+
+Values are published raw (SI units, as the model emits them). Mapping cloud
+cover and precipitation to a Home Assistant condition is the integration's job,
+so that changing the mapping does not require regenerating the data.
+
+Usage:
+    python tools/build_forecast_data.py --out dist
+    python tools/build_forecast_data.py --out dist --limit 5   # quick check
+"""
+
+from __future__ import annotations
+
+import argparse
+import bz2
+import json
+import re
+import sys
+import urllib.request
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from aladin import Grid, iter_messages  # noqa: E402
+
+ALADIN_BASE = "https://opendata.chmi.cz/meteorology/weather/nwp_aladin/CZ_1km"
+STATION_METADATA = "https://opendata.chmi.cz/meteorology/climate/now/metadata"
+USER_AGENT = "home-assistant-chmu-weather forecast builder"
+SCHEMA_VERSION = 1
+
+# ALADIN file name stem -> (output key, converter). Hourly fields only.
+HOURLY_PARAMS: dict[str, tuple[str, Any]] = {
+    "CLSTEMPERATURE": ("temperature", lambda v: round(v - 273.15, 1)),
+    "CLSHUMI_RELATIVE": ("humidity", lambda v: round(min(max(v, 0.0), 1.0) * 100)),
+    "SURFNEBUL_TOTALE": (
+        "cloud_coverage",
+        lambda v: round(min(max(v, 0.0), 1.0) * 100),
+    ),
+    "CLSWIND_SPEED": ("wind_speed", lambda v: round(v * 3.6, 1)),  # m/s -> km/h
+    "CLSWIND_DIREC": ("wind_bearing", lambda v: round(v) % 360),
+    "PRECIP_TYPE": ("precipitation_type", lambda v: round(v)),
+}
+
+# Cumulative from the start of the run; published as a per-hour difference.
+PRECIPITATION_PARAM = "SURFPREC_TOTAL"
+
+# 12 hour extremes, stamped 06Z (overnight low) and 18Z (daytime high).
+DAILY_PARAMS = {
+    "CLSMAXI_TEMPERAT": ("temperature", 18),
+    "CLSMINI_TEMPERAT": ("templow", 6),
+}
+
+REQUIRED_PARAMS = (*HOURLY_PARAMS, PRECIPITATION_PARAM, *DAILY_PARAMS)
+
+_RUN_FILE_RE = re.compile(r"ALADCZ1K4opendata_(\d{10})_([A-Z0-9_]+)\.grb\.bz2")
+
+
+def _get(url: str, timeout: int = 300) -> bytes:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.read()
+
+
+def find_latest_run() -> str:
+    """Return the newest run id (YYYYMMDDHH) that has every parameter we need."""
+    available: dict[str, set[str]] = defaultdict(set)
+    for hour in ("00", "06", "12", "18"):
+        index = _get(f"{ALADIN_BASE}/{hour}/", timeout=60).decode("utf-8", "replace")
+        for run, param in _RUN_FILE_RE.findall(index):
+            available[run].add(param)
+
+    complete = [
+        run for run, params in available.items() if set(REQUIRED_PARAMS) <= params
+    ]
+    if not complete:
+        raise RuntimeError("no ALADIN run on opendata has the full parameter set")
+    return max(complete)
+
+
+def load_stations(limit: int | None = None) -> list[dict[str, Any]]:
+    """Fetch ČHMÚ station metadata (today's file, yesterday's as a fallback)."""
+    for delta in (0, 1):
+        day = (datetime.now(UTC) - timedelta(days=delta)).strftime("%Y%m%d")
+        try:
+            payload = json.loads(_get(f"{STATION_METADATA}/meta1-{day}.json", 60))
+        except OSError:
+            continue
+        # header: WSI, GH_ID, FULL_NAME, GEOGR1 (lon), GEOGR2 (lat), ELEVATION, ...
+        # The metadata occasionally repeats a station verbatim, so key by WSI.
+        by_id = {
+            row[0]: {
+                "station_id": row[0],
+                "name": row[2],
+                "longitude": row[3],
+                "latitude": row[4],
+                "elevation": row[5],
+            }
+            for row in payload["data"]["data"]["values"]
+        }
+        stations = sorted(by_id.values(), key=lambda s: s["station_id"])
+        return stations[:limit] if limit else stations
+    raise RuntimeError("could not download ČHMÚ station metadata")
+
+
+def _param_url(run: str, param: str) -> str:
+    return f"{ALADIN_BASE}/{run[8:]}/ALADCZ1K4opendata_{run}_{param}.grb.bz2"
+
+
+def _sample(run: str, param: str, coordinates: list[tuple[float, float]]):
+    """Download one parameter and return {valid_time: [value per coordinate]}."""
+    blob = _get(_param_url(run, param))
+    series: dict[datetime, list[float]] = {}
+    indices: list[int] | None = None
+    for message in iter_messages(bz2.decompress(blob)):
+        if indices is None:
+            indices = [message.grid.index(lat, lon) for lat, lon in coordinates]
+        series[message.valid_time] = [message.value_at(i) for i in indices]
+    print(
+        f"  {param:18s} {len(blob) / 1e6:5.1f} MB  {len(series):3d} steps", flush=True
+    )
+    return series
+
+
+def read_grid(run: str) -> Grid:
+    """Read the grid definition from the smallest file of a run."""
+    blob = _get(_param_url(run, "PRECIP_TYPE"))
+    return next(iter_messages(bz2.decompress(blob))).grid
+
+
+def build(out_dir: Path, limit: int | None = None) -> None:
+    run = find_latest_run()
+    reference = datetime.strptime(run, "%Y%m%d%H").replace(tzinfo=UTC)
+    print(f"ALADIN CZ_1km run {reference:%Y-%m-%d %HZ}", flush=True)
+
+    stations = load_stations(limit)
+    grid = read_grid(run)
+    inside = [s for s in stations if grid.contains(s["latitude"], s["longitude"])]
+    skipped = len(stations) - len(inside)
+    print(f"{len(inside)} stations in domain ({skipped} outside, skipped)", flush=True)
+
+    coordinates = [(s["latitude"], s["longitude"]) for s in inside]
+
+    hourly: dict[str, dict[datetime, list[float]]] = {}
+    for param in HOURLY_PARAMS:
+        hourly[param] = _sample(run, param, coordinates)
+    cumulative = _sample(run, PRECIPITATION_PARAM, coordinates)
+    daily = {param: _sample(run, param, coordinates) for param in DAILY_PARAMS}
+
+    # Cumulative precipitation -> per-hour amounts, shared by all stations.
+    precip_times = sorted(cumulative)
+    precipitation: dict[datetime, list[float]] = {}
+    previous = [0.0] * len(inside)
+    for when in precip_times:
+        current = cumulative[when]
+        precipitation[when] = [
+            max(c - p, 0.0) for c, p in zip(current, previous, strict=True)
+        ]
+        previous = current
+
+    generated = datetime.now(UTC).replace(microsecond=0)
+    version_dir = out_dir / "v1"
+    version_dir.mkdir(parents=True, exist_ok=True)
+
+    steps = sorted(set().union(*(series.keys() for series in hourly.values())))
+    for position, station in enumerate(inside):
+        entries = []
+        for when in steps:
+            entry = {"datetime": when.isoformat().replace("+00:00", "Z")}
+            for param, (key, convert) in HOURLY_PARAMS.items():
+                values = hourly[param].get(when)
+                if values is not None:
+                    entry[key] = convert(values[position])
+            rain = precipitation.get(when)
+            if rain is not None:
+                entry["precipitation"] = round(rain[position], 1)
+            entries.append(entry)
+
+        days: dict[str, dict[str, Any]] = {}
+        for param, (key, hour) in DAILY_PARAMS.items():
+            for when, values in daily[param].items():
+                if when.hour != hour:
+                    continue
+                day = days.setdefault(
+                    when.date().isoformat(), {"date": when.date().isoformat()}
+                )
+                day[key] = round(values[position] - 273.15, 1)
+
+        document = {
+            "schema": SCHEMA_VERSION,
+            "model": "ALADIN CZ_1km",
+            "run": reference.isoformat().replace("+00:00", "Z"),
+            "generated": generated.isoformat().replace("+00:00", "Z"),
+            "station": station,
+            "hourly": entries,
+            "daily": [days[key] for key in sorted(days)],
+        }
+        path = version_dir / f"{station['station_id']}.json"
+        path.write_text(
+            json.dumps(document, ensure_ascii=False, separators=(",", ":")),
+            encoding="utf-8",
+        )
+
+    index = {
+        "schema": SCHEMA_VERSION,
+        "model": "ALADIN CZ_1km",
+        "run": reference.isoformat().replace("+00:00", "Z"),
+        "generated": generated.isoformat().replace("+00:00", "Z"),
+        "hours": len(steps),
+        "stations": [
+            {"station_id": s["station_id"], "name": s["name"]} for s in inside
+        ],
+    }
+    (version_dir / "index.json").write_text(
+        json.dumps(index, ensure_ascii=False, separators=(",", ":")), encoding="utf-8"
+    )
+
+    written = sum(p.stat().st_size for p in version_dir.glob("*.json"))
+    print(
+        f"wrote {len(inside) + 1} files, {written / 1e6:.1f} MB, "
+        f"{len(steps)} hourly steps",
+        flush=True,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=Path("dist"))
+    parser.add_argument("--limit", type=int, help="only build the first N stations")
+    args = parser.parse_args()
+    build(args.out, args.limit)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

ČHMÚ's forecast endpoints are national only. `data-provider.chmi.cz/api/graphs/graf.forecast` ignores `lat`/`lon`/`nuts` (byte-identical response), and the opendata forecasts are prose text for 14 regions. On 2026-09-08 the regional maxima spanned 21–32 °C, so a single national number is off by up to 8 °C — and ~10 °C for mountain stations.

## What

`opendata.chmi.cz/.../nwp_aladin/CZ_1km/` is the only per-point source. It turns out to be GRIB **edition 1** on a **regular lat/lon** grid (501×290, `La1=48.5 Lo1=12.0 Di=0.014 Dj=0.009`, scan mode `0x40`) with **simple packing**, 12 bits/value, no bitmap — so one grid point is plain bit arithmetic. No eccodes, no cfgrib, no numpy.

~70 MB of GRIB per model run is too much to pull into Home Assistant, so the sampling runs in CI:

| File | What |
|---|---|
| `tools/aladin.py` | GRIB1 reader, standard library only |
| `tools/build_forecast_data.py` | Samples every station, writes `dist/v1/{wsi}.json` |
| `tests/test_aladin.py` | 11 tests on hand-built GRIB messages, no network |
| `.github/workflows/forecast-data.yml` | Cron 01:30/07:30/13:30/19:30 UTC → GitHub Pages |

Published fields: temperature, humidity, cloud cover, wind speed/bearing, precipitation amount and type — 73 hourly steps to +72 h, plus daily high/low from the 12 h extrema fields. Values stay raw so changing the Home Assistant condition mapping doesn't require regenerating data.

## Measured on the live 2026-09-08 00Z run

```
758 stations in domain (1 outside, skipped)
wrote 759 files, 9.6 MB, 73 hourly steps
real 0m6.5s
```

Per station: 12.6 KB raw, **1.5 KB gzipped**. Verified over a local HTTP server:

```
Plzeň, Mikulka  (360 m)          Sněžka, Poštovna  (1602 m)
  2026-09-08  high 28.8  low 11.5   2026-09-08  high 19.6  low 13.3
  2026-09-09  high 20.3  low 15.1   2026-09-09  high 18.0  low 14.4
  2026-09-10  high 18.4  low  9.2   2026-09-10  high 10.1  low  6.0
```

9.2 °C apart on the same day — the spread the national feed flattens. Plzeň's 28.8 falls inside ČHMÚ's own regional text forecast of "27 až 30 °C".

## Not in this PR

- The `weather` platform that consumes this. Data pipeline only.
- **Scheduled workflows on public repos are disabled after 60 days with no repository activity.** This workflow deploys via a Pages artifact and makes no commits, so a dormant repo silently stops the feed. Worth a keepalive and a staleness guard in the integration before shipping a user-facing entity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)