### PR TITLE
fix(api): derive ČHMÚ file names from the UTC day and bound staleness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Measurements no longer disappear for the first hours of the day (#5). ČHMÚ
+  names the 10 minute data file after the UTC day and publishes a new day's
+  first chunk only at about 01:02 UTC, while the integration asked for the
+  file named after the host's *local* day - so from local midnight until
+  03:02 CEST (02:02 CET) every poll 404'd. The file name now follows the UTC
+  day and falls back to the previous one, so the sensors keep the last real
+  measurement and a restart inside that window no longer leaves the
+  integration unloaded
+- Station metadata is likewise requested for the UTC day rather than the local
+  one, so adding or reconfiguring a station in that window no longer needs a
+  second request to succeed
+- A malformed response body or a change to ČHMÚ's document shape is reported
+  as itself instead of being retried as a missing day and served as yesterday's
+  data
+
+### Added
+- A measurement is only served while it is fresh enough to mean anything: one
+  more than 2 hours old logs a warning, and one more than 6 hours old is
+  refused, so the sensors go unavailable rather than presenting a stale reading
+  as current. A station that stops reporting used to leave its last value
+  standing all day
+- `measured_at` attribute on every measurement sensor, carrying the time ČHMÚ
+  measured the value. A sensor state is stamped with the time of the poll, so
+  this is the only place the real age is visible
+
 ## [1.5.0] - 2026-09-08
 
 ### Added

--- a/custom_components/chmu/ARCHITECTURE.md
+++ b/custom_components/chmu/ARCHITECTURE.md
@@ -91,6 +91,12 @@ table is hardcoded in the integration. Two families of stations are offered:
 
 `api.station_id_to_wsi()` / `api.wsi_to_station_id()` convert between the two.
 
+**Every published file is named after the UTC day**, and the timestamps inside
+carry a `Z`. A ČHMÚ file name is therefore never derived from the host's local
+date — on a Prague host the local day rolls over one or two hours before the
+UTC day, so a local-dated name asks for a file that does not exist yet. See
+`api._utc_day_candidates()`.
+
 **Metadata files**
 
 | File | Content | Used for |
@@ -162,12 +168,20 @@ decided by temperature.
 **Base URL:** `https://opendata.chmi.cz/meteorology/climate`
 
 **Endpoints:**
-- Daily data: `/now/data/YYYY-MM-DD.json`
-- Hourly data: `/recent/data/1hour/dly-1-YYMMDD-HHMM-{station_id}.json`
+- 10-minute data: `/now/data/10m-{WSI}-{YYYYMMDD}.json` (one file per station
+  per UTC day, rewritten hourly at about `HH:02` UTC)
+- Station metadata: `/now/metadata/meta1-{YYYYMMDD}.json`, `meta2-{YYYYMMDD}.json`
+  (published at about `00:02` UTC on the day they are named after)
 
 **Polling Strategy:**
-1. Try today's daily data
-2. Fallback to recent hourly data
+1. Try the current UTC day's file
+2. Fall back to the previous UTC day — a new day's first chunk does not appear
+   until about `01:02` UTC, so for the first hour of every UTC day only the
+   previous file exists
+3. Bound the result's age with `MEASUREMENT_STALE_AFTER` (warn) and
+   `MEASUREMENT_UNUSABLE_AFTER` (refuse), so a station that has gone quiet
+   cannot be served as a current reading. The measurement time is exposed as
+   the `measured_at` attribute on every sensor
 3. Try last 6 hours of data
 4. Use simulated data if all fail (development mode)
 

--- a/custom_components/chmu/__init__.py
+++ b/custom_components/chmu/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .api import ChmuApi
+from .api import ChmuApi, MeasurementUnusable
 from .forecast import ChmuForecastApi, ForecastUnusable, StationForecast
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,9 +48,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ChmuConfigEntry) -> bool
     forecast_api = ChmuForecastApi(station_id)
 
     async def async_update_data():
-        """Fetch data from API."""
+        """Fetch the station's own measurements.
+
+        A measurement too old to present is reported as such rather than as a
+        communication error: the download worked, so calling it one would send
+        the next person debugging this at the wrong thing.
+        """
         try:
             return await hass.async_add_executor_job(api.get_current_data)
+        except MeasurementUnusable as err:
+            raise UpdateFailed(
+                f"No usable ČHMÚ measurement for station {station_id}: {err}"
+            ) from err
         except Exception as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 

--- a/custom_components/chmu/api.py
+++ b/custom_components/chmu/api.py
@@ -2,7 +2,7 @@
 
 import logging
 import re
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import requests
@@ -13,6 +13,8 @@ from .const import (
     API_METADATA_PATH,
     API_NOW_PATH,
     ELEMENT_MAP,
+    MEASUREMENT_STALE_AFTER,
+    MEASUREMENT_UNUSABLE_AFTER,
     METADATA_ELEMENTS_PREFIX,
     METADATA_STATIONS_PREFIX,
     OBS_TYPE_10M,
@@ -24,6 +26,54 @@ _LOGGER = logging.getLogger(__name__)
 _CR_TEXT_FORECAST_RE = re.compile(
     r'href="(web_pCRntx_\d{6}\.json)"[^<]*</a>\s+(\d{2}-[A-Za-z]{3}-\d{4}\s+\d{2}:\d{2})'
 )
+
+
+class NoStationData(Exception):
+    """A downloaded file carries no measurement rows for this station.
+
+    Deliberately not a ValueError: requests raises ValueError subclasses for a
+    malformed body and for a broken URL, and those must keep propagating. This
+    one means the file parsed and simply holds nothing for us, so another day
+    is worth trying.
+    """
+
+
+class MeasurementUnusable(Exception):
+    """The newest measurement is too old to present as a current reading.
+
+    Same shape as ForecastUnusable in forecast.py: the download worked, the
+    answer is just not usable, so it must not be served either.
+    """
+
+
+def _utc_day_candidates() -> tuple[datetime, datetime]:
+    """Return the current and previous UTC day, in the order to try them.
+
+    ČHMÚ names every published file after the UTC day. Both the metadata and
+    the measurement path need that pair, and they used to derive it
+    separately - which is how they came to disagree in the first place (#5).
+    """
+    now = datetime.now(UTC)
+    return now, now - timedelta(days=1)
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    """Parse a ČHMÚ measurement timestamp into an aware datetime.
+
+    Returns None for anything unparseable rather than failing the poll: an
+    unexpected stamp format must not cost the reading itself, it only means
+    the age cannot be checked.
+    """
+    if not isinstance(value, str):
+        return None
+
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
 
 # Fallback used when the station metadata cannot be downloaded.
 _FALLBACK_STATIONS = {
@@ -80,8 +130,14 @@ def new_session() -> requests.Session:
 def _fetch_metadata_with_fallback(
     session: requests.Session, log_context: str, prefix: str = METADATA_STATIONS_PREFIX
 ) -> dict[str, Any]:
-    """Fetch today's metadata or fall back to previous day when necessary."""
-    date_str = datetime.now().strftime("%Y%m%d")
+    """Fetch today's metadata or fall back to previous day when necessary.
+
+    The file is named after the UTC day and published at about 00:02 UTC, so
+    the fallback covers only that couple of minutes - plus a day ČHMÚ skips
+    entirely.
+    """
+    now, previous_day = _utc_day_candidates()
+    date_str = now.strftime("%Y%m%d")
     filename = f"{prefix}-{date_str}.json"
     url = f"{API_BASE_URL}{API_METADATA_PATH}/{filename}"
 
@@ -94,8 +150,7 @@ def _fetch_metadata_with_fallback(
     except requests.exceptions.HTTPError as err:
         if err.response.status_code == 404:
             # Try previous day's metadata
-            yesterday = datetime.now() - timedelta(days=1)
-            date_str = yesterday.strftime("%Y%m%d")
+            date_str = previous_day.strftime("%Y%m%d")
             filename = f"{prefix}-{date_str}.json"
             url = f"{API_BASE_URL}{API_METADATA_PATH}/{filename}"
 
@@ -227,11 +282,7 @@ class ChmuApi:
 
     def get_current_data(self) -> dict[str, Any]:
         """Get current weather data from ČHMÚ."""
-        now = datetime.now()
-
-        data = self._fetch_10min_data(now)
-        if not data:
-            raise ValueError(f"No data available for station {self.station_id}")
+        data = self._fetch_10min_data_with_fallback()
 
         # Text forecast is optional; measured station data should still work
         # even when forecast endpoint is unavailable.
@@ -252,26 +303,97 @@ class ChmuApi:
 
         return data
 
+    def _fetch_10min_data_with_fallback(self) -> dict[str, Any]:
+        """Return the latest usable 10 minute measurements for this station.
+
+        ČHMÚ names the data file after the UTC day but does not publish a new
+        day's first chunk until about 01:02 UTC, so for the first hour of every
+        UTC day only the previous day's file exists. Reading it keeps the
+        sensors on the last real measurement instead of dropping to
+        unavailable, and stops a restart inside that window from failing setup
+        with ConfigEntryNotReady.
+
+        How old the result may be is bounded by _check_freshness, not by which
+        file it came from: the fallback is written for a gap of about an hour,
+        but a station that stops reporting leaves yesterday's file sitting
+        there for a whole day.
+        """
+        now, previous_day = _utc_day_candidates()
+
+        data = self._fetch_10min_data(now)
+        if not data:
+            data = self._fetch_10min_data(previous_day)
+            if data:
+                _LOGGER.info(
+                    "ČHMÚ has published no data for station %s on %s yet, "
+                    "reading %s instead",
+                    self.station_id,
+                    now.strftime("%Y-%m-%d"),
+                    previous_day.strftime("%Y-%m-%d"),
+                )
+
+        if not data:
+            raise ValueError(f"No data available for station {self.station_id}")
+
+        self._check_freshness(data, now)
+        return data
+
+    def _check_freshness(self, data: dict[str, Any], now: datetime) -> None:
+        """Warn about an ageing measurement, refuse an unusable one.
+
+        A sensor state carries no age of its own - Home Assistant stamps it
+        with the time it was written - so an unbounded reading would enter long
+        term statistics as if it had just been measured.
+        """
+        measured_at = _parse_timestamp(data.get("timestamp"))
+        if measured_at is None:
+            return
+
+        age = now - measured_at
+        if age > MEASUREMENT_UNUSABLE_AFTER:
+            raise MeasurementUnusable(
+                f"the newest measurement for station {self.station_id} is from "
+                f"{measured_at:%Y-%m-%d %H:%MZ}, "
+                f"{age // timedelta(hours=1)} hours old"
+            )
+
+        if age > MEASUREMENT_STALE_AFTER:
+            _LOGGER.warning(
+                "The newest ČHMÚ measurement for station %s is %d hours old "
+                "(%s); the station may have stopped reporting",
+                self.station_id,
+                age // timedelta(hours=1),
+                data["timestamp"],
+            )
+
     def _fetch_10min_data(self, date: datetime) -> dict[str, Any] | None:
-        """Fetch 10-minute interval data for a specific date."""
-        # Format: 10m-{WSI}-{YYYYMMDD}.json
+        """Fetch 10-minute interval data for one UTC date.
+
+        Returns None when ČHMÚ has nothing for that date, so the caller can
+        try another day: the file may not be published yet, or it may carry no
+        rows for this station. A malformed body or an unexpected document
+        shape is not that case and keeps propagating.
+        """
+        # Format: 10m-{WSI}-{YYYYMMDD}.json, named after the UTC day - the
+        # measurement timestamps it holds are UTC as well.
         date_str = date.strftime("%Y%m%d")
         filename = f"10m-{self.wsi}-{date_str}.json"
         url = f"{API_BASE_URL}{API_NOW_PATH}/{filename}"
 
-        _LOGGER.debug(f"Fetching data from: {url}")
+        _LOGGER.debug("Fetching data from: %s", url)
 
         try:
             response = self.session.get(url, timeout=30)
             response.raise_for_status()
-
-            json_data = response.json()
-            return self._parse_chmu_data(json_data)
+            return self._parse_chmu_data(response.json())
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404:
-                _LOGGER.debug(f"Data file not found: {filename}")
+                _LOGGER.debug("Data file not found: %s", filename)
                 return None
             raise
+        except NoStationData as e:
+            _LOGGER.debug("Nothing for station %s in %s: %s", self.wsi, filename, e)
+            return None
 
     def _parse_chmu_data(self, json_data: dict[str, Any]) -> dict[str, Any]:
         """Parse CHMU JSON data format.
@@ -283,10 +405,20 @@ class ChmuApi:
         T (temp), H (humidity), P (pressure), SRA10M (precip),
         F (wind speed), D (wind dir)
         """
-        values = json_data.get("data", {}).get("data", {}).get("values", [])
+        # An absent values array means the published format changed, which is
+        # a different problem from a day with nothing in it and must not be
+        # retried as one.
+        document = json_data.get("data")
+        payload = document.get("data") if isinstance(document, dict) else None
+        if not isinstance(payload, dict) or "values" not in payload:
+            raise ValueError(
+                "Unexpected ČHMÚ document: no data.data.values array. "
+                "The published format may have changed."
+            )
 
+        values = payload["values"]
         if not values:
-            raise ValueError("No data values found in response")
+            raise NoStationData("the file carries no measurement rows")
 
         # Get the most recent values for each element
         latest_values = {}
@@ -311,7 +443,7 @@ class ChmuApi:
                 latest_values[element] = {"value": value, "timestamp": timestamp}
 
         if not latest_values:
-            raise ValueError(f"No data found for station {self.station_id}")
+            raise NoStationData(f"no rows for station {self.station_id}")
 
         # Map CHMU elements to our sensor values. Elements the station does not
         # measure are left out entirely instead of being reported as None.
@@ -334,7 +466,7 @@ class ChmuApi:
             return latest_values["T"]["timestamp"]
 
         timestamps = [entry["timestamp"] for entry in latest_values.values()]
-        return max(timestamps) if timestamps else datetime.now().isoformat()
+        return max(timestamps) if timestamps else datetime.now(UTC).isoformat()
 
     def _fetch_latest_cr_text_forecast(self) -> dict[str, Any]:
         """Fetch latest Czech Republic text forecast JSON."""

--- a/custom_components/chmu/const.py
+++ b/custom_components/chmu/const.py
@@ -39,6 +39,17 @@ FORECAST_SCHEMA_VERSION = 1
 FORECAST_STALE_AFTER = timedelta(hours=18)
 FORECAST_UNUSABLE_AFTER = timedelta(hours=48)
 
+# ČHMÚ rewrites a station's 10 minute file hourly at about HH:02 UTC, so a
+# healthy poll reads a measurement at most about 70 minutes old. Same two
+# threshold shape as the forecast above, and for the same reason: the
+# previous-day fallback in api.py exists to cover a gap of about an hour, but
+# nothing stops it from finding a day old row when a station goes quiet, and a
+# sensor state carries no age of its own - Home Assistant stamps it with the
+# time it was written. Warn while the reading is still worth showing, refuse
+# once serving it would put a stale value into long term statistics.
+MEASUREMENT_STALE_AFTER = timedelta(hours=2)
+MEASUREMENT_UNUSABLE_AFTER = timedelta(hours=6)
+
 # Station metadata files (meta1 = stations, meta2 = measured elements per station)
 METADATA_STATIONS_PREFIX = "meta1"
 METADATA_ELEMENTS_PREFIX = "meta2"

--- a/custom_components/chmu/sensor.py
+++ b/custom_components/chmu/sensor.py
@@ -82,6 +82,21 @@ class ChmuSensorBase(CoordinatorEntity, SensorEntity):
             "suggested_area": "Outdoors",
         }
 
+    @property
+    def extra_state_attributes(self):
+        """Expose when the value was measured, not when it was written.
+
+        Home Assistant stamps a state with the time the poll wrote it, which
+        for a polled sensor is not when the measurement was taken. During the
+        nightly publishing gap the reading legitimately comes from the previous
+        UTC day, so the real time has to be visible somewhere.
+        """
+        if not self.coordinator.data:
+            return None
+
+        measured_at = self.coordinator.data.get("timestamp")
+        return {"measured_at": measured_at} if measured_at else None
+
 
 class ChmuTemperatureSensor(ChmuSensorBase):
     """Temperature sensor."""

--- a/custom_components/chmu/weather.py
+++ b/custom_components/chmu/weather.py
@@ -123,10 +123,10 @@ class ChmuWeather(CoordinatorEntity, WeatherEntity):
     def available(self) -> bool:
         """Return whether either source has something to report.
 
-        The two feeds fail independently: ČHMÚ stops publishing a station's
-        10 minute file for a while after local midnight, which must not take
-        the forecast down with it - an unavailable entity makes
-        weather.get_forecasts raise for anything that calls it.
+        The two feeds fail independently: ČHMÚ can stop publishing a
+        station's 10 minute file, which must not take the forecast down with
+        it - an unavailable entity makes weather.get_forecasts raise for
+        anything that calls it.
         """
         return bool(self._measured) or self._forecast is not None
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 """Tests for CHMU API helpers."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 from importlib import import_module
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -11,20 +11,32 @@ import requests
 api = import_module("custom_components.chmu.api")
 
 
-@pytest.fixture(autouse=True)
-def freeze_datetime(monkeypatch):
-    """Freeze datetime.now() to a known value for deterministic URLs."""
+def _freeze(monkeypatch, utc_now: datetime, local_now: datetime | None = None):
+    """Patch api.datetime so now(UTC) and a naive now() can disagree.
+
+    They are allowed to differ on purpose: ČHMÚ names its files after the UTC
+    day, while the local day on a Prague host rolls over one or two hours
+    earlier. Reading the local day is the bug behind issue #5, so the tests
+    have to be able to tell the two apart.
+    """
+    naive = local_now if local_now is not None else utc_now.replace(tzinfo=None)
 
     class FixedDatetime(datetime):
         @classmethod
-        def now(cls):
-            return cls(2025, 12, 21)
-
-        @classmethod
-        def utcnow(cls):
-            return cls(2025, 12, 21)
+        def now(cls, tz=None):
+            # Converted rather than returned as-is, so that asking for a
+            # non-UTC zone yields that zone's wall clock. Returning the UTC
+            # instant for every tz would make the double blind to the aware
+            # form of #5 - naming the file after the Prague day.
+            return utc_now.astimezone(tz) if tz is not None else naive
 
     monkeypatch.setattr(api, "datetime", FixedDatetime)
+
+
+@pytest.fixture(autouse=True)
+def freeze_datetime(monkeypatch):
+    """Freeze the clock to a known instant for deterministic URLs."""
+    _freeze(monkeypatch, datetime(2025, 12, 21, 12, 0, tzinfo=UTC))
 
 
 @pytest.fixture
@@ -172,7 +184,7 @@ def test_fetch_10min_data_uses_full_wsi_for_automatic_station(mock_session):
     }
     mock_session.get.return_value = _http_response(200, payload)
 
-    data = client._fetch_10min_data(api.datetime.now())
+    data = client._fetch_10min_data(api.datetime.now(UTC))
 
     url = mock_session.get.call_args.args[0]
     assert url.endswith("10m-0-203-0-10102001101-20251221.json")
@@ -284,3 +296,209 @@ def test_get_current_data_adds_weather_description(monkeypatch):
     assert data["temperature"] == 12
     assert data["weather_description"] == "Jasno až polojasno."
     assert data["weather_description_timestamp"] == "2026-03-02T03:19:33.067Z"
+
+
+def _10min_payload(wsi: str, timestamp: str, temperature: float) -> dict:
+    """Build a 10m data payload holding one temperature row."""
+    return {"data": {"data": {"values": [[wsi, "T", timestamp, temperature, "", 0.0]]}}}
+
+
+def test_fetch_10min_data_falls_back_to_previous_utc_day(mock_session, monkeypatch):
+    """Just after UTC midnight only the previous day's file exists (#5)."""
+    _freeze(monkeypatch, datetime(2025, 12, 21, 0, 30, tzinfo=UTC))
+    client = api.ChmuApi("11518", "Praha-Ruzyne")
+    mock_session.get.side_effect = [
+        _http_response(404),
+        _http_response(
+            200,
+            _10min_payload("0-20000-0-11518", "2025-12-20T23:50:00Z", -1.5),
+        ),
+    ]
+
+    data = client._fetch_10min_data_with_fallback()
+
+    assert data["temperature"] == -1.5
+    assert data["timestamp"] == "2025-12-20T23:50:00Z"
+
+    urls = [call.args[0] for call in mock_session.get.call_args_list]
+    assert urls[0].endswith("10m-0-20000-0-11518-20251221.json")
+    assert urls[1].endswith("10m-0-20000-0-11518-20251220.json")
+
+
+def test_fetch_10min_data_names_the_file_after_the_utc_day(mock_session, monkeypatch):
+    """A Prague host is already on the next local day at 00:30 CET (#5).
+
+    The file must still be the UTC one, which exists and holds current data,
+    not the local-dated one, which ČHMÚ has not published yet.
+    """
+    _freeze(
+        monkeypatch,
+        datetime(2025, 12, 21, 23, 30, tzinfo=UTC),
+        local_now=datetime(2025, 12, 22, 0, 30),
+    )
+    client = api.ChmuApi("11518", "Praha-Ruzyne")
+    mock_session.get.return_value = _http_response(
+        200, _10min_payload("0-20000-0-11518", "2025-12-21T23:20:00Z", 0.5)
+    )
+
+    data = client._fetch_10min_data_with_fallback()
+
+    assert data["temperature"] == 0.5
+    assert mock_session.get.call_count == 1
+    url = mock_session.get.call_args.args[0]
+    assert url.endswith("10m-0-20000-0-11518-20251221.json")
+
+
+def test_fetch_10min_data_falls_back_when_file_has_no_station_rows(
+    mock_session, monkeypatch
+):
+    """A published file carrying nothing for this station is not usable."""
+    _freeze(monkeypatch, datetime(2025, 12, 21, 0, 30, tzinfo=UTC))
+    client = api.ChmuApi("11518", "Praha-Ruzyne")
+    mock_session.get.side_effect = [
+        _http_response(
+            200, _10min_payload("0-20000-0-11782", "2025-12-21T00:20:00Z", 9.9)
+        ),
+        _http_response(
+            200, _10min_payload("0-20000-0-11518", "2025-12-20T23:50:00Z", -1.5)
+        ),
+    ]
+
+    assert client._fetch_10min_data_with_fallback()["temperature"] == -1.5
+    assert mock_session.get.call_count == 2
+
+
+def test_fetch_10min_data_raises_when_neither_day_is_available(mock_session):
+    """Both days missing is a real failure and must surface as one."""
+    client = api.ChmuApi("11518", "Praha-Ruzyne")
+    mock_session.get.side_effect = [_http_response(404), _http_response(404)]
+
+    with pytest.raises(ValueError, match="No data available for station 11518"):
+        client._fetch_10min_data_with_fallback()
+
+    # Without this the test also passes against the pre-fix code, which raised
+    # the identical message after a single request.
+    assert mock_session.get.call_count == 2
+
+
+def test_fetch_10min_data_propagates_server_errors(mock_session):
+    """A 500 is not a missing day, so it is not retried as one."""
+    client = api.ChmuApi("11518", "Praha-Ruzyne")
+    mock_session.get.side_effect = [_http_response(500), _http_response(404)]
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        client._fetch_10min_data_with_fallback()
+
+    assert mock_session.get.call_count == 1
+
+
+def test_metadata_is_fetched_for_the_utc_day(mock_session, monkeypatch):
+    """Metadata file names follow the UTC day too."""
+    _freeze(
+        monkeypatch,
+        datetime(2025, 12, 21, 23, 30, tzinfo=UTC),
+        local_now=datetime(2025, 12, 22, 0, 30),
+    )
+    mock_session.get.side_effect = [
+        _http_response(200, _elements_metadata(META2_ROWS)),
+        _http_response(200, _stations_metadata(META1_ROWS)),
+    ]
+
+    api.get_stations_with_coords()
+
+    urls = [call.args[0] for call in mock_session.get.call_args_list]
+    assert urls[0].endswith("meta2-20251221.json")
+    assert urls[1].endswith("meta1-20251221.json")
+
+
+def test_fetch_10min_data_propagates_a_malformed_body(mock_session):
+    """A truncated body or an HTML error page must not read as a quiet day.
+
+    requests raises JSONDecodeError, which is a ValueError subclass, so it
+    would be swallowed by a broad except and served as yesterday's data.
+    """
+    client = api.ChmuApi("11518", "Praha-Ruzyne")
+    broken = _http_response(200)
+    broken.json.side_effect = requests.exceptions.JSONDecodeError("boom", "", 0)
+    mock_session.get.side_effect = [broken, _http_response(200)]
+
+    with pytest.raises(requests.exceptions.JSONDecodeError):
+        client._fetch_10min_data_with_fallback()
+
+    # The previous day was never reached: this is a failure, not an absence.
+    assert mock_session.get.call_count == 1
+
+
+def test_fetch_10min_data_propagates_an_unexpected_document_shape(mock_session):
+    """A renamed field is a format change and must be reported as one.
+
+    Retrying it as a missing day would report a structural break as an absence
+    of data, which is the worst possible hint for whoever has to debug it from
+    a user's log excerpt.
+    """
+    client = api.ChmuApi("11518", "Praha-Ruzyne")
+    renamed = {"data": {"data": {"rows": [["0-20000-0-11518", "T", "x", 1.0]]}}}
+    mock_session.get.return_value = _http_response(200, renamed)
+
+    with pytest.raises(ValueError, match="no data.data.values array"):
+        client._fetch_10min_data_with_fallback()
+
+    assert mock_session.get.call_count == 1
+
+
+def test_fetch_10min_data_refuses_a_measurement_past_the_bound(
+    mock_session, monkeypatch
+):
+    """A station quiet since yesterday must not be served as current.
+
+    The fallback covers a gap of about an hour. A station that stops reporting
+    leaves yesterday's file in place all day, and serving its last row would
+    feed a day old value into long term statistics stamped as fresh.
+    """
+    _freeze(monkeypatch, datetime(2025, 12, 21, 12, 0, tzinfo=UTC))
+    client = api.ChmuApi("11518", "Praha-Ruzyne")
+    mock_session.get.side_effect = [
+        _http_response(404),
+        _http_response(
+            200, _10min_payload("0-20000-0-11518", "2025-12-20T23:50:00Z", -1.5)
+        ),
+    ]
+
+    with pytest.raises(api.MeasurementUnusable, match="12 hours old"):
+        client._fetch_10min_data_with_fallback()
+
+
+def test_fetch_10min_data_warns_about_an_ageing_measurement(
+    mock_session, monkeypatch, caplog
+):
+    """Between the two thresholds the reading is served, but not silently."""
+    _freeze(monkeypatch, datetime(2025, 12, 21, 3, 0, tzinfo=UTC))
+    client = api.ChmuApi("11518", "Praha-Ruzyne")
+    mock_session.get.return_value = _http_response(
+        200, _10min_payload("0-20000-0-11518", "2025-12-20T23:50:00Z", -1.5)
+    )
+
+    with caplog.at_level("WARNING"):
+        data = client._fetch_10min_data_with_fallback()
+
+    assert data["temperature"] == -1.5
+    assert "3 hours old" in caplog.text
+
+
+def test_fetch_10min_data_serves_the_nightly_gap_without_a_warning(
+    mock_session, monkeypatch, caplog
+):
+    """The case the fallback exists for is normal operation, not a problem."""
+    _freeze(monkeypatch, datetime(2025, 12, 21, 0, 30, tzinfo=UTC))
+    client = api.ChmuApi("11518", "Praha-Ruzyne")
+    mock_session.get.side_effect = [
+        _http_response(404),
+        _http_response(
+            200, _10min_payload("0-20000-0-11518", "2025-12-20T23:50:00Z", -1.5)
+        ),
+    ]
+
+    with caplog.at_level("WARNING"):
+        assert client._fetch_10min_data_with_fallback()["temperature"] == -1.5
+
+    assert caplog.text == ""

--- a/tests/test_weather_ha.py
+++ b/tests/test_weather_ha.py
@@ -14,9 +14,11 @@ forecast subscription contract.
 import json
 import threading
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 pytest.importorskip(
     "pytest_homeassistant_custom_component",
@@ -366,10 +368,10 @@ async def test_a_measurement_outage_leaves_the_forecast_usable(
 ):
     """The two feeds fail independently.
 
-    ČHMÚ stops publishing a station's 10 minute file for a while after local
-    midnight. That used to make the entity unavailable, and an unavailable
-    entity makes weather.get_forecasts raise for every automation that calls
-    it, even though the forecast itself was fine.
+    A station can stop publishing its 10 minute file for a while. That used to
+    make the entity unavailable, and an unavailable entity makes
+    weather.get_forecasts raise for every automation that calls it, even though
+    the forecast itself was fine.
     """
     measured_response.side_effect = ValueError("no data available for station 11450")
     coordinator = setup_entry.runtime_data.coordinator
@@ -405,3 +407,126 @@ async def test_unload_removes_the_entity(hass, setup_entry):
 
     # Home Assistant keeps a restored placeholder around after an unload.
     assert hass.states.get("weather.plzen_mikulka").state == "unavailable"
+
+
+# ČHMÚ names the 10 minute file after the UTC day but publishes the new day's
+# first chunk only at about 01:02 UTC, so this instant is inside the nightly
+# gap reported in issue #5.
+MIDNIGHT_WINDOW = datetime(2026, 9, 9, 0, 30, tzinfo=UTC)
+
+PREVIOUS_DAY_10MIN = {
+    "data": {
+        "data": {
+            # Newest row first, on purpose: with the newest row last, an
+            # implementation that simply keeps the last row it sees would pass
+            # the assertion below without ever comparing timestamps.
+            "values": [
+                ["0-20000-0-11450", "T", "2026-09-08T23:50:00Z", 11.4, "", 0.0],
+                ["0-20000-0-11450", "T", "2026-09-08T23:40:00Z", 11.9, "", 0.0],
+                ["0-20000-0-11450", "H", "2026-09-08T23:50:00Z", 88.0, "", 0.0],
+            ]
+        }
+    }
+}
+
+
+def _json_response(payload: dict) -> MagicMock:
+    """Build a 200 response serving the given JSON body."""
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.raise_for_status.return_value = None
+    response.json.return_value = payload
+    return response
+
+
+def _not_found_response() -> MagicMock:
+    """Build a response that raises the 404 requests itself would raise."""
+    response = MagicMock()
+    response.status_code = 404
+    response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "404", response=SimpleNamespace(status_code=404)
+    )
+    return response
+
+
+async def test_setup_survives_the_nightly_chmu_data_gap(hass, freezer):
+    """A restart inside the nightly gap must still set the integration up.
+
+    Reading the previous UTC day keeps the sensors on the last real
+    measurement. Before that, the first refresh failed, setup raised
+    ConfigEntryNotReady and an unlucky reboot left the integration missing
+    entirely until ČHMÚ published again (#5).
+    """
+    freezer.move_to(MIDNIGHT_WINDOW)
+
+    def dispatch(url, *args, **kwargs):
+        if "10m-0-20000-0-11450-20260909.json" in url:
+            return _not_found_response()
+        if "10m-0-20000-0-11450-20260908.json" in url:
+            return _json_response(PREVIOUS_DAY_10MIN)
+        # The text forecast and the ALADIN file are out of scope here, and
+        # neither may be required for setup to finish.
+        raise OSError(f"unavailable: {url}")
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Plzeň, Mikulka",
+        data={
+            "station_id": "11450",
+            "station_name": "Plzeň, Mikulka",
+            "station_elements": ["temperature", "humidity"],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    with patch("requests.Session.get", side_effect=dispatch):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        assert entry.runtime_data.coordinator.last_update_success is True
+
+        temperature = hass.states.get("sensor.plzen_mikulka_temperature")
+        # The newest row of the previous day, not the first one in the file.
+        assert float(temperature.state) == 11.4
+        assert float(hass.states.get("sensor.plzen_mikulka_humidity").state) == 88.0
+        # Home Assistant stamps the state with the time of the poll, so the
+        # real measurement time is only visible as an attribute.
+        assert temperature.attributes["measured_at"] == "2026-09-08T23:50:00Z"
+        assert temperature.last_updated > datetime(2026, 9, 9, tzinfo=UTC)
+
+
+async def test_a_measurement_past_the_bound_is_refused(hass, freezer):
+    """A station quiet since yesterday goes unavailable, not silently stale.
+
+    Serving the last row would put a day old value into long term statistics
+    stamped with the time of the poll, which is worse than the outage the
+    fallback was added to survive.
+    """
+    freezer.move_to(datetime(2026, 9, 9, 12, 0, tzinfo=UTC))
+
+    def dispatch(url, *args, **kwargs):
+        if "10m-0-20000-0-11450-20260909.json" in url:
+            return _not_found_response()
+        if "10m-0-20000-0-11450-20260908.json" in url:
+            return _json_response(PREVIOUS_DAY_10MIN)
+        raise OSError(f"unavailable: {url}")
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Plzeň, Mikulka",
+        data={
+            "station_id": "11450",
+            "station_name": "Plzeň, Mikulka",
+            "station_elements": ["temperature", "humidity"],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    with patch("requests.Session.get", side_effect=dispatch):
+        # Twelve hours old: setup fails the way any unreachable source does,
+        # and Home Assistant retries it.
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get("sensor.plzen_mikulka_temperature") is None


### PR DESCRIPTION
Fixes #5.

## The bug

ČHMÚ names every published file after the **UTC** day — the measurement timestamps inside end in `Z` — and the 10-minute file for a new UTC day is not written until about `01:02` UTC, because the `00:02` run still flushes the previous day.

`_fetch_10min_data` built the name from `datetime.now()`, the host's **local** date, and had no fallback:

| Host timezone | Every poll 404s |
|---|---|
| CEST (UTC+2) | `00:00` → `03:02` local — the "~3 a.m." in the report |
| CET (UTC+1) | `00:00` → `02:02` local |

So all sensors went unavailable for hours every night, and a restart inside that window raised `ConfigEntryNotReady` — the integration did not load at all, which is what @TekuSP hit on the issue.

Verified against the live API before touching anything:

```
$ curl -sI .../10m-0-20000-0-11518-20260909.json | grep last-modified
last-modified: Wed, 09 Sep 2026 12:02:03 GMT      # rewritten hourly at HH:02 UTC
$ ... _fetch_10min_data(datetime.now() + timedelta(days=1))
None                                              # -> ValueError -> UpdateFailed
```

## The fix

Both the metadata and the measurement path now take their date from a shared `_utc_day_candidates()`. They had each derived it separately, which is how they came to disagree in the first place — `_fetch_metadata_with_fallback` already had a previous-day fallback (from #1), the measurement path never got one.

`_fetch_10min_data_with_fallback` tries the current UTC day, then the previous one.

## Why the fallback alone would have been worse than the bug

The previous day's file sits there all day, so a station that stops reporting would have had its last row served as a live reading — `last_updated` = now, straight into long-term statistics, `available` true, with nothing anywhere recording the real age. Worst case ~42 h.

The age is therefore bounded the same way `forecast.py` already bounds a retained forecast:

| Age of newest measurement | Behaviour |
|---|---|
| < 2 h (`MEASUREMENT_STALE_AFTER`) | served silently — the nightly gap lands here at ~40 min |
| 2–6 h | served, logs a warning |
| > 6 h (`MEASUREMENT_UNUSABLE_AFTER`) | `MeasurementUnusable` → sensors go unavailable honestly |

Every measurement sensor also exposes **`measured_at`**. A polled sensor state is stamped with the time of the poll, so this is the only place the real measurement time is visible.

## Narrowed exception handling

`requests` raises `ValueError` subclasses (`JSONDecodeError`, `MissingSchema`, `InvalidURL`), so the catch that selects the retryable case cannot be `ValueError` — a truncated body or an HTML maintenance page would be swallowed and answered with yesterday's data at DEBUG level.

- `NoStationData` (deliberately *not* a `ValueError`) = the file parsed and holds nothing for this station, so another day is worth trying.
- A malformed body, or a missing `data.data.values` array (i.e. ČHMÚ changed the format), propagates with a message that says so, instead of being reported as an absence of data.

## Verification

- **90 tests** pass (was 72). `ruff check` / `ruff format --check` / HACS validation clean; `pyright` clean on `api.py`.
- **Live** against `opendata.chmi.cz`: normal path reads at ~37 min age; a future UTC day genuinely 404s and the bound refuses an artificially 11 h old row.
- **End-to-end in a real Home Assistant** (`pytest-homeassistant-custom-component`): setup succeeds inside the gap and reports the previous day's newest row with its `measured_at`; a 12 h old row fails setup instead.
- **Mutation-checked** — reverting any one of {UTC date, fallback, age bound, narrow catch} fails a named test:

  | Reverted | Caught by |
  |---|---|
  | UTC date → local date | 8 tests |
  | previous-day fallback | 6 tests |
  | age bound | 3 tests |
  | `NoStationData` → `ValueError` | 3 tests |

  This also caught a bad test double: `tests/test_api.py::_freeze` keyed on *whether* a tz was passed rather than which one, so reintroducing this very bug as `datetime.now(ZoneInfo("Europe/Prague"))` passed all 27 tests. Fixed to `utc_now.astimezone(tz)`; the variant now fails as it should.

`ARCHITECTURE.md` records the UTC-day fact and the publishing times, so the next change here starts from the right model.

Not released: the `CHANGELOG.md` entry is under `## [Unreleased]` and `manifest.json` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
