### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.6.0] - 2026-09-09
+
+### Added
+- A measurement is only served while it is fresh enough to mean anything: one
+  more than 2 hours old logs a warning, and one more than 6 hours old is
+  refused, so the sensors go unavailable rather than presenting a stale reading
+  as current. A station that stops reporting used to leave its last value
+  standing all day
+- `measured_at` attribute on every measurement sensor, carrying the time ČHMÚ
+  measured the value. A sensor state is stamped with the time of the poll, so
+  this is the only place the real age is visible
 
 ### Fixed
 - Measurements no longer disappear for the first hours of the day (#5). ČHMÚ
@@ -22,16 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A malformed response body or a change to ČHMÚ's document shape is reported
   as itself instead of being retried as a missing day and served as yesterday's
   data
-
-### Added
-- A measurement is only served while it is fresh enough to mean anything: one
-  more than 2 hours old logs a warning, and one more than 6 hours old is
-  refused, so the sensors go unavailable rather than presenting a stale reading
-  as current. A station that stops reporting used to leave its last value
-  standing all day
-- `measured_at` attribute on every measurement sensor, carrying the time ČHMÚ
-  measured the value. A sensor state is stamped with the time of the poll, so
-  this is the only place the real age is visible
 
 ## [1.5.0] - 2026-09-08
 

--- a/custom_components/chmu/manifest.json
+++ b/custom_components/chmu/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/lipelix/home-assistant-chmu-weather/issues",
   "requirements": ["requests>=2.31.0"],
-  "version": "1.5.0"
+  "version": "1.6.0"
 }


### PR DESCRIPTION
Release prep for 1.6.0, on top of #13.

- `manifest.json` → `1.6.0`
- `CHANGELOG.md`: `## [Unreleased]` → `## [1.6.0] - 2026-09-09`, sections reordered to Keep a Changelog order (Added before Fixed)

**Minor, not patch.** Beyond fixing #5 this release changes what the sensors do when ČHMÚ data goes stale — past six hours they go unavailable instead of holding their last value — and adds the `measured_at` attribute.

Once this is merged, pushing `v1.6.0` triggers `release.yml`, which takes the release body from the `1.6.0` changelog section (via `changelog-reader-action`, which fails the build if that section is missing) and attaches `chmu.zip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
