### PR TITLE
fix(ci): retry ČHMÚ downloads in the forecast builder

### DIFF
--- a/.github/workflows/forecast-data.yml
+++ b/.github/workflows/forecast-data.yml
@@ -32,9 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     # The whole job takes about a minute; GitHub's default would let a hung
     # download sit on the concurrency group for six hours, i.e. a whole model
-    # cycle. The headroom is for the retries in build_forecast_data.py: a
-    # download that keeps timing out rather than failing outright can now spend
-    # four socket timeouts on one file before giving up.
+    # cycle. The headroom is for the retries in build_forecast_data.py, which
+    # stop retrying 20 minutes into the run for exactly this reason: a job
+    # killed here publishes nothing, so the retrying has to leave enough of
+    # this budget to decode and upload what it did manage to download.
     timeout-minutes: 30
     environment:
       name: github-pages

--- a/.github/workflows/forecast-data.yml
+++ b/.github/workflows/forecast-data.yml
@@ -32,8 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     # The whole job takes about a minute; GitHub's default would let a hung
     # download sit on the concurrency group for six hours, i.e. a whole model
-    # cycle.
-    timeout-minutes: 20
+    # cycle. The headroom is for the retries in build_forecast_data.py: a
+    # download that keeps timing out rather than failing outright can now spend
+    # four socket timeouts on one file before giving up.
+    timeout-minutes: 30
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- The forecast publishing job no longer loses a whole model cycle to one
+  dropped connection. It makes about fifteen requests to ČHMÚ per run and made
+  each of them exactly once, so a single TCP timeout failed the job and left
+  the published forecast on the previous run until the next scheduled slot -
+  which GitHub delays by up to five hours on top of the six hour interval.
+  Downloads now retry four times with a growing backoff. A 404 is still
+  answered immediately, so the station metadata fallback keeps working
+
 ## [1.6.0] - 2026-09-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   each of them exactly once, so a single TCP timeout failed the job and left
   the published forecast on the previous run until the next scheduled slot -
   which GitHub delays by up to five hours on top of the six hour interval.
-  Downloads now retry four times with a growing backoff. A 404 is still
-  answered immediately, so the station metadata fallback keeps working
+  A failed download is now attempted three more times with a growing backoff,
+  and the retrying is bounded so it cannot eat the time the job needs to
+  publish. A refusal such as 404 still comes straight back, so the station
+  metadata fallback keeps working; 408, 425 and 429 are the server asking to be
+  asked again, so they are retried like any other transport failure
 
 ## [1.6.0] - 2026-09-09
 

--- a/tests/test_build_forecast_data.py
+++ b/tests/test_build_forecast_data.py
@@ -7,7 +7,9 @@ decides whether one dropped connection costs a whole model cycle.
 
 import http.client
 import sys
+import time
 import urllib.error
+from datetime import UTC, datetime, timedelta
 from email.message import Message
 from pathlib import Path
 
@@ -22,13 +24,27 @@ import build_forecast_data as builder  # noqa: E402
 URL = "https://opendata.chmi.cz/meteorology/weather/nwp_aladin/CZ_1km/12/"
 
 
+class _OnRead:
+    """Marks an outcome that fails while the body is read, not on connect.
+
+    The distinction is the whole point of one of these tests: a truncated
+    download surfaces from response.read(), so an implementation that only
+    guards the urlopen call has to be seen to fail.
+    """
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+
 class _Response:
     """Minimal stand-in for the object urlopen returns."""
 
-    def __init__(self, body: bytes) -> None:
+    def __init__(self, body: bytes | Exception) -> None:
         self._body = body
 
     def read(self) -> bytes:
+        if isinstance(self._body, Exception):
+            raise self._body
         return self._body
 
     def __enter__(self):
@@ -46,8 +62,17 @@ def no_sleeping(monkeypatch):
     return slept
 
 
+@pytest.fixture(autouse=True)
+def fresh_deadline(monkeypatch):
+    """Every test starts with the retry deadline far away.
+
+    Otherwise the tests would inherit however long the interpreter had been up.
+    """
+    monkeypatch.setattr(builder, "_STARTED", time.monotonic())
+
+
 class _Urlopen:
-    """A urlopen double that plays out one outcome per call, and counts them.
+    """A urlopen double that plays out one outcome per call, and logs the calls.
 
     A class rather than a closure with an attribute bolted on, so that the
     call log is a declared member and the tests type-check.
@@ -56,10 +81,14 @@ class _Urlopen:
     def __init__(self, *outcomes) -> None:
         self._remaining = list(outcomes)
         self.calls: list[str] = []
+        self.timeouts: list[int | None] = []
 
     def __call__(self, request, timeout=None) -> _Response:
         self.calls.append(request.full_url)
+        self.timeouts.append(timeout)
         outcome = self._remaining.pop(0)
+        if isinstance(outcome, _OnRead):
+            return _Response(outcome.error)
         if isinstance(outcome, Exception):
             raise outcome
         return _Response(outcome)
@@ -86,6 +115,20 @@ def test_get_retries_a_connect_timeout_and_succeeds(monkeypatch, no_sleeping):
     assert no_sleeping == [5.0]
 
 
+def test_get_passes_the_caller_s_timeout_to_every_attempt(monkeypatch):
+    """A retry must not quietly widen or drop the socket timeout.
+
+    The deadline above only bounds the build if each attempt gives up when it
+    was told to.
+    """
+    urlopen = _Urlopen(ConnectionResetError("reset by peer"), b"listing")
+    monkeypatch.setattr(builder.urllib.request, "urlopen", urlopen)
+
+    builder._get(URL, timeout=60)
+
+    assert urlopen.timeouts == [60, 60]
+
+
 def test_get_backs_off_between_attempts(monkeypatch, no_sleeping):
     """Waits longer each time, and gives up rather than looping forever."""
     urlopen = _Urlopen(
@@ -100,10 +143,37 @@ def test_get_backs_off_between_attempts(monkeypatch, no_sleeping):
     assert no_sleeping == [5.0, 10.0, 15.0]
 
 
+def test_get_stops_retrying_once_the_job_is_nearly_out_of_time(
+    monkeypatch, no_sleeping
+):
+    """Late in the run a failure is reported rather than retried.
+
+    Retrying past the deadline only makes it likelier that GitHub kills the job
+    before it can publish anything, which is worse than one reported failure.
+    """
+    monkeypatch.setattr(
+        builder,
+        "_STARTED",
+        time.monotonic() - builder.RETRY_DEADLINE.total_seconds() - 1,
+    )
+    urlopen = _Urlopen(urllib.error.URLError(TimeoutError("timed out")), b"listing")
+    monkeypatch.setattr(builder.urllib.request, "urlopen", urlopen)
+
+    with pytest.raises(urllib.error.URLError):
+        builder._get(URL, timeout=60)
+
+    assert len(urlopen.calls) == 1
+    assert no_sleeping == []
+
+
 def test_get_retries_a_body_that_stops_midway(monkeypatch, no_sleeping):
-    """A truncated 7 MB download is not an OSError, and still deserves a retry."""
+    """A truncated 7 MB download is not an OSError, and still deserves a retry.
+
+    It surfaces from read(), not from urlopen, so the retry has to cover the
+    body transfer and not only the connect.
+    """
     urlopen = _Urlopen(
-        http.client.IncompleteRead(b"half a grib", 5_000_000),
+        _OnRead(http.client.IncompleteRead(b"half a grib", 5_000_000)),
         b"a whole grib",
     )
     monkeypatch.setattr(builder.urllib.request, "urlopen", urlopen)
@@ -130,50 +200,79 @@ def test_get_retries_a_server_error(monkeypatch, no_sleeping):
     assert len(urlopen.calls) == 2
 
 
-def test_get_retries_a_rate_limit(monkeypatch, no_sleeping):
-    """429 is the one 4xx that means "later", so it is the one 4xx we retry."""
-    urlopen = _Urlopen(_http_error(429), b"listing")
+# Spelled out rather than read from builder.RETRY_STATUS: parametrising over the
+# implementation's own set means removing a code from it also removes the case
+# that would have caught the removal.
+@pytest.mark.parametrize("code", [408, 425, 429])
+def test_get_retries_the_statuses_that_mean_ask_again(monkeypatch, no_sleeping, code):
+    """408, 425 and 429 are the server asking to be asked again, not a refusal.
+
+    They are the only 4xx worth another attempt, and 408 in particular is the
+    same failure as a client-side timeout with the server reporting it instead.
+    """
+    urlopen = _Urlopen(_http_error(code), b"listing")
     monkeypatch.setattr(builder.urllib.request, "urlopen", urlopen)
 
     assert builder._get(URL) == b"listing"
     assert len(urlopen.calls) == 2
 
 
-def test_get_does_not_retry_a_missing_file(monkeypatch, no_sleeping):
-    """404 must come straight back.
+@pytest.mark.parametrize("code", [400, 403, 404, 410, 451])
+def test_get_does_not_retry_a_refusal(monkeypatch, no_sleeping, code):
+    """A plain 4xx must come straight back.
 
     load_stations asks for today's metadata first and falls back to yesterday's
-    on OSError. Retrying the 404 would only delay that fallback, and metadata
+    when it fails. Retrying the 404 would only delay that fallback, and metadata
     for the current UTC day is legitimately absent for the first minutes of it.
     """
-    urlopen = _Urlopen(_http_error(404), b"never reached")
+    urlopen = _Urlopen(_http_error(code), b"never reached")
     monkeypatch.setattr(builder.urllib.request, "urlopen", urlopen)
 
     with pytest.raises(urllib.error.HTTPError) as raised:
         builder._get(URL, timeout=60)
 
-    assert raised.value.code == 404
+    assert raised.value.code == code
     assert len(urlopen.calls) == 1
     assert no_sleeping == []
 
 
 def test_load_stations_still_falls_back_to_yesterday(monkeypatch, no_sleeping):
     """The 404 fallback survives the retry loop being added under it."""
-    day_asked: list[str] = []
-
-    def urlopen(request, timeout=None):
-        day_asked.append(request.full_url)
-        if len(day_asked) == 1:
-            raise _http_error(404)
-        return _Response(
-            b'{"data": {"data": {"values": ['
-            b'["0-20000-0-11518", 1, "Praha", 14.4, 50.1, 300]]}}}'
-        )
-
+    urlopen = _Urlopen(
+        _http_error(404),
+        b'{"data": {"data": {"values": ['
+        b'["0-20000-0-11518", 1, "Praha", 14.4, 50.1, 300]]}}}',
+    )
     monkeypatch.setattr(builder.urllib.request, "urlopen", urlopen)
 
     stations = builder.load_stations()
 
     assert [s["station_id"] for s in stations] == ["0-20000-0-11518"]
-    assert len(day_asked) == 2, "today's file was retried instead of falling back"
+    today = datetime.now(UTC)
+    assert urlopen.calls == [
+        f"{builder.STATION_METADATA}/meta1-{today:%Y%m%d}.json",
+        f"{builder.STATION_METADATA}/meta1-{today - timedelta(days=1):%Y%m%d}.json",
+    ], "today's file was retried instead of falling back to yesterday's"
     assert no_sleeping == []
+
+
+def test_load_stations_falls_back_when_todays_metadata_is_truncated(
+    monkeypatch, no_sleeping
+):
+    """A truncated body is the failure _get retries, so it must reach the fallback.
+
+    It is not an OSError, so catching only that would let it out of build() and
+    yesterday's file would never be asked for.
+    """
+    truncated = _OnRead(http.client.IncompleteRead(b"{", 4000))
+    urlopen = _Urlopen(
+        *[truncated] * builder.RETRY_ATTEMPTS,
+        b'{"data": {"data": {"values": ['
+        b'["0-20000-0-11518", 1, "Praha", 14.4, 50.1, 300]]}}}',
+    )
+    monkeypatch.setattr(builder.urllib.request, "urlopen", urlopen)
+
+    stations = builder.load_stations()
+
+    assert [s["station_id"] for s in stations] == ["0-20000-0-11518"]
+    assert len(urlopen.calls) == builder.RETRY_ATTEMPTS + 1

--- a/tests/test_build_forecast_data.py
+++ b/tests/test_build_forecast_data.py
@@ -1,0 +1,179 @@
+"""Tests for the forecast builder's download layer.
+
+The builder itself runs in CI against ~63 MB of ČHMÚ GRIB, so only the part
+that decides whether to try again is exercised here - which is the part that
+decides whether one dropped connection costs a whole model cycle.
+"""
+
+import http.client
+import sys
+import urllib.error
+from email.message import Message
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "tools") not in sys.path:
+    sys.path.insert(0, str(ROOT / "tools"))
+
+import build_forecast_data as builder  # noqa: E402
+
+URL = "https://opendata.chmi.cz/meteorology/weather/nwp_aladin/CZ_1km/12/"
+
+
+class _Response:
+    """Minimal stand-in for the object urlopen returns."""
+
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+@pytest.fixture(autouse=True)
+def no_sleeping(monkeypatch):
+    """Record the backoff instead of waiting it out."""
+    slept: list[float] = []
+    monkeypatch.setattr(builder.time, "sleep", slept.append)
+    return slept
+
+
+class _Urlopen:
+    """A urlopen double that plays out one outcome per call, and counts them.
+
+    A class rather than a closure with an attribute bolted on, so that the
+    call log is a declared member and the tests type-check.
+    """
+
+    def __init__(self, *outcomes) -> None:
+        self._remaining = list(outcomes)
+        self.calls: list[str] = []
+
+    def __call__(self, request, timeout=None) -> _Response:
+        self.calls.append(request.full_url)
+        outcome = self._remaining.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return _Response(outcome)
+
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(URL, code, "boom", Message(), None)
+
+
+def test_get_retries_a_connect_timeout_and_succeeds(monkeypatch, no_sleeping):
+    """The failure that killed run 34350942136 must not fail the run.
+
+    urllib reports a TCP connect timeout as URLError wrapping TimeoutError,
+    which is what the traceback in that run showed.
+    """
+    urlopen = _Urlopen(
+        urllib.error.URLError(TimeoutError("timed out")),
+        b"<html>listing</html>",
+    )
+    monkeypatch.setattr(builder.urllib.request, "urlopen", urlopen)
+
+    assert builder._get(URL, timeout=60) == b"<html>listing</html>"
+    assert len(urlopen.calls) == 2
+    assert no_sleeping == [5.0]
+
+
+def test_get_backs_off_between_attempts(monkeypatch, no_sleeping):
+    """Waits longer each time, and gives up rather than looping forever."""
+    urlopen = _Urlopen(
+        *[urllib.error.URLError(TimeoutError("timed out"))] * builder.RETRY_ATTEMPTS
+    )
+    monkeypatch.setattr(builder.urllib.request, "urlopen", urlopen)
+
+    with pytest.raises(urllib.error.URLError):
+        builder._get(URL, timeout=60)
+
+    assert len(urlopen.calls) == builder.RETRY_ATTEMPTS
+    assert no_sleeping == [5.0, 10.0, 15.0]
+
+
+def test_get_retries_a_body_that_stops_midway(monkeypatch, no_sleeping):
+    """A truncated 7 MB download is not an OSError, and still deserves a retry."""
+    urlopen = _Urlopen(
+        http.client.IncompleteRead(b"half a grib", 5_000_000),
+        b"a whole grib",
+    )
+    monkeypatch.setattr(builder.urllib.request, "urlopen", urlopen)
+
+    assert builder._get(URL) == b"a whole grib"
+    assert len(urlopen.calls) == 2
+
+
+def test_get_retries_a_reset_connection(monkeypatch, no_sleeping):
+    """A bare socket error reaches _get too, not only the URLError wrapper."""
+    urlopen = _Urlopen(ConnectionResetError("reset by peer"), b"listing")
+    monkeypatch.setattr(builder.urllib.request, "urlopen", urlopen)
+
+    assert builder._get(URL) == b"listing"
+    assert len(urlopen.calls) == 2
+
+
+def test_get_retries_a_server_error(monkeypatch, no_sleeping):
+    """502 from the CDN is transient; the run should ride it out."""
+    urlopen = _Urlopen(_http_error(502), b"listing")
+    monkeypatch.setattr(builder.urllib.request, "urlopen", urlopen)
+
+    assert builder._get(URL) == b"listing"
+    assert len(urlopen.calls) == 2
+
+
+def test_get_retries_a_rate_limit(monkeypatch, no_sleeping):
+    """429 is the one 4xx that means "later", so it is the one 4xx we retry."""
+    urlopen = _Urlopen(_http_error(429), b"listing")
+    monkeypatch.setattr(builder.urllib.request, "urlopen", urlopen)
+
+    assert builder._get(URL) == b"listing"
+    assert len(urlopen.calls) == 2
+
+
+def test_get_does_not_retry_a_missing_file(monkeypatch, no_sleeping):
+    """404 must come straight back.
+
+    load_stations asks for today's metadata first and falls back to yesterday's
+    on OSError. Retrying the 404 would only delay that fallback, and metadata
+    for the current UTC day is legitimately absent for the first minutes of it.
+    """
+    urlopen = _Urlopen(_http_error(404), b"never reached")
+    monkeypatch.setattr(builder.urllib.request, "urlopen", urlopen)
+
+    with pytest.raises(urllib.error.HTTPError) as raised:
+        builder._get(URL, timeout=60)
+
+    assert raised.value.code == 404
+    assert len(urlopen.calls) == 1
+    assert no_sleeping == []
+
+
+def test_load_stations_still_falls_back_to_yesterday(monkeypatch, no_sleeping):
+    """The 404 fallback survives the retry loop being added under it."""
+    day_asked: list[str] = []
+
+    def urlopen(request, timeout=None):
+        day_asked.append(request.full_url)
+        if len(day_asked) == 1:
+            raise _http_error(404)
+        return _Response(
+            b'{"data": {"data": {"values": ['
+            b'["0-20000-0-11518", 1, "Praha", 14.4, 50.1, 300]]}}}'
+        )
+
+    monkeypatch.setattr(builder.urllib.request, "urlopen", urlopen)
+
+    stations = builder.load_stations()
+
+    assert [s["station_id"] for s in stations] == ["0-20000-0-11518"]
+    assert len(day_asked) == 2, "today's file was retried instead of falling back"
+    assert no_sleeping == []

--- a/tools/build_forecast_data.py
+++ b/tools/build_forecast_data.py
@@ -78,31 +78,49 @@ _RUN_FILE_RE = re.compile(r"ALADCZ1K4opendata_(\d{10})_([A-Z0-9_]+)\.grb\.bz2")
 RETRY_ATTEMPTS = 4
 RETRY_BACKOFF = timedelta(seconds=5)
 
+# Retries are only worth having if the build still gets to finish. GitHub kills
+# the job at timeout-minutes and a killed run publishes nothing at all, so the
+# waiting is bounded once for the whole process rather than once per URL: this
+# build makes about fifteen requests, and fifteen of them each willing to spend
+# their full attempt budget on a sick server would need hours. Past the deadline
+# a transport failure is reported instead of retried, which leaves the rest of
+# the job's time to decode and publish.
+RETRY_DEADLINE = timedelta(minutes=20)
+_STARTED = time.monotonic()
+
+# The server answers these by asking to be asked again, so they belong with the
+# transport failures rather than with the other 4xx: 408 is "you were too slow",
+# 425 is "too early", 429 is "not this often".
+RETRY_STATUS = frozenset({408, 425, 429})
+
 
 def _retryable(error: Exception) -> bool:
     """Is this failure worth another attempt?
 
-    A 4xx is the server answering rather than failing, so retrying only burns
-    the run's time - and load_stations needs a 404 back promptly so it can ask
-    for yesterday's metadata instead. Everything else reaching here is a
+    Any other 4xx is the server answering rather than failing, so retrying only
+    burns the run's time - and load_stations needs a 404 back promptly so it can
+    ask for yesterday's metadata instead. Everything else reaching here is a
     transport failure, which is exactly the transient case retries exist for.
     """
     if isinstance(error, urllib.error.HTTPError):
-        return error.code == 429 or error.code >= 500
+        return error.code in RETRY_STATUS or error.code >= 500
     return True
 
 
-def _get(url: str, timeout: int = 300) -> bytes:
-    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-
+def _get(url: str, timeout: int = 120) -> bytes:
     for attempt in range(1, RETRY_ATTEMPTS + 1):
+        # Rebuilt per attempt: urllib's redirect handler records each hop on the
+        # Request it is given, and a reused one carries those hops into the next
+        # attempt until it trips the handler's own loop detector.
+        request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
         try:
             with urllib.request.urlopen(request, timeout=timeout) as response:
                 return response.read()
         # HTTPException covers a body that stops mid-download; these files are
         # tens of megabytes, so that is a real outcome and not an OSError.
         except (OSError, http.client.HTTPException) as error:
-            if attempt == RETRY_ATTEMPTS or not _retryable(error):
+            out_of_time = time.monotonic() - _STARTED > RETRY_DEADLINE.total_seconds()
+            if attempt == RETRY_ATTEMPTS or out_of_time or not _retryable(error):
                 raise
             delay = RETRY_BACKOFF * attempt
             print(
@@ -138,7 +156,10 @@ def load_stations(limit: int | None = None) -> list[dict[str, Any]]:
         day = (datetime.now(UTC) - timedelta(days=delta)).strftime("%Y%m%d")
         try:
             payload = json.loads(_get(f"{STATION_METADATA}/meta1-{day}.json", 60))
-        except OSError:
+        # Same pair as _get retries on: a truncated body is not an OSError, and
+        # today's metadata failing for any transport reason is exactly when
+        # yesterday's is worth asking for.
+        except (OSError, http.client.HTTPException):
             continue
         # header: WSI, GH_ID, FULL_NAME, GEOGR1 (lon), GEOGR2 (lat), ELEVATION, ...
         # The metadata occasionally repeats a station verbatim, so key by WSI.

--- a/tools/build_forecast_data.py
+++ b/tools/build_forecast_data.py
@@ -23,9 +23,12 @@ from __future__ import annotations
 
 import argparse
 import bz2
+import http.client
 import json
 import re
 import sys
+import time
+import urllib.error
 import urllib.request
 from collections import defaultdict
 from datetime import UTC, datetime, timedelta
@@ -67,11 +70,50 @@ REQUIRED_PARAMS = (*HOURLY_PARAMS, PRECIPITATION_PARAM, *DAILY_PARAMS)
 
 _RUN_FILE_RE = re.compile(r"ALADCZ1K4opendata_(\d{10})_([A-Z0-9_]+)\.grb\.bz2")
 
+# One build makes about fifteen requests to opendata.chmi.cz and used to make
+# each of them once, so a single dropped connection failed the whole run - and
+# the next scheduled attempt is a model cycle away, which GitHub then delays by
+# up to five hours on top. That is what happened to run 34350942136: a TCP
+# connect timeout on the very first directory listing.
+RETRY_ATTEMPTS = 4
+RETRY_BACKOFF = timedelta(seconds=5)
+
+
+def _retryable(error: Exception) -> bool:
+    """Is this failure worth another attempt?
+
+    A 4xx is the server answering rather than failing, so retrying only burns
+    the run's time - and load_stations needs a 404 back promptly so it can ask
+    for yesterday's metadata instead. Everything else reaching here is a
+    transport failure, which is exactly the transient case retries exist for.
+    """
+    if isinstance(error, urllib.error.HTTPError):
+        return error.code == 429 or error.code >= 500
+    return True
+
 
 def _get(url: str, timeout: int = 300) -> bytes:
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(request, timeout=timeout) as response:
-        return response.read()
+
+    for attempt in range(1, RETRY_ATTEMPTS + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return response.read()
+        # HTTPException covers a body that stops mid-download; these files are
+        # tens of megabytes, so that is a real outcome and not an OSError.
+        except (OSError, http.client.HTTPException) as error:
+            if attempt == RETRY_ATTEMPTS or not _retryable(error):
+                raise
+            delay = RETRY_BACKOFF * attempt
+            print(
+                f"  {url} failed ({error!r}), attempt {attempt}/{RETRY_ATTEMPTS}, "
+                f"retrying in {delay.total_seconds():.0f}s",
+                file=sys.stderr,
+                flush=True,
+            )
+            time.sleep(delay.total_seconds())
+
+    raise AssertionError("unreachable: the last attempt either returns or raises")
 
 
 def find_latest_run() -> str:


### PR DESCRIPTION
## Why

Scheduled run [34350942136](https://github.com/lipelix/home-assistant-chmu-weather/actions/runs/34350942136) failed at 12:25 UTC today:

```
File "tools/build_forecast_data.py", line 81, in find_latest_run
  index = _get(f"{ALADIN_BASE}/{hour}/", timeout=60).decode("utf-8", "replace")
urllib.error.URLError: <urlopen error timed out>
```

A TCP connect timeout on the **first** request of the run, before a byte of GRIB. `_get` made every request exactly once, and one build issues ~17 requests to `opendata.chmi.cz` (4 directory listings + station metadata + 9 GRIB files, ~80 MB) — so any single transient failure killed the job.

The cost is not one wasted run. Pages keeps serving the previous artifact until the next scheduled slot, and GitHub delays these by up to ~5 h on top of the 6 h interval — the 01:30 slot fired at 06:25, the 07:30 slot at 12:25. One dropped packet can therefore cost ~11 h of forecast freshness. 1 of this workflow's first 6 runs died this way.

opendata is healthy now (all four listings 200 in ~40 ms), so nothing upstream needs fixing — only the single-attempt download.

## What

- `_get` retries 4 times with a 5/10/15 s backoff.
- Retries every transport failure, plus `http.client.HTTPException` — a body that stops midway is a real outcome on a 25 MB file and is *not* an `OSError` — plus 429 and 5xx.
- **A 4xx is not retried.** It is the server answering rather than failing, and `load_stations` depends on a prompt 404 to fall back to yesterday's metadata file. A test pins that fallback.
- Job timeout 20 → 30 min, so a download that keeps timing out rather than failing outright still fits inside the job.

No `custom_components/` change, so no version bump — the changelog entry sits under `[Unreleased]`.

## Verification

| Check | Result |
|---|---|
| `pytest` | 98 pass (90 + 8 new) |
| `ruff check` + `ruff format --check` | clean |
| `pyright` | only the pre-existing `tools/` import-resolution error `test_aladin.py` also shows |
| Real build against live ČHMÚ, `--limit 3` | 80 MB, 8.4 s, 06Z run |
| Same build with 2 connect timeouts injected (first listing + one GRIB) | recovered in 20 s, output **byte-identical** to the clean run |

Mutation testing — each reverted piece fails named tests, none passes silently:

| Mutation | Failing tests |
|---|---|
| `RETRY_ATTEMPTS = 1` | 6 |
| `_retryable` always `True` (404 retried) | 2 |
| catch `OSError` only, drop `HTTPException` | 1 |

The injected-failure run logged exactly what CI will show:

```
  https://opendata.chmi.cz/.../CZ_1km/00/ failed (URLError(TimeoutError('timed out'))), attempt 1/4, retrying in 5s
```

## Note, out of scope

The site was on the 00Z run all morning because `find_latest_run()` deliberately prefers an older *complete* run over failing, so the delayed 06:25 job published 00Z. Working as intended; the scheduling drift itself is a separate question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
